### PR TITLE
Reduce multiplication factor on hardfork 1 due to bigger initial supply

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -3788,7 +3788,7 @@ void database::apply_hardfork( uint32_t hardfork )
 #ifndef IS_TEST_NET
          elog( "HARDFORK 1 at block ${b}", ("b", head_block_num()) );
 #endif
-         perform_vesting_share_split( 1000000 );
+         perform_vesting_share_split( 10000 );
 #ifdef IS_TEST_NET
          {
             custom_operation test_op;


### PR DESCRIPTION
Use smaller multiplication factor on hardfork 1 due to bigger initial supply.

In current testnet, the amount of VESTS is overflowing.

Need some math to judge whether the new value is good enough.

Perhaps better to relaunch testnet after this change.