### PR TITLE
Prevent all threads from using the same POW nonce.

### DIFF
--- a/libraries/plugins/witness/witness.cpp
+++ b/libraries/plugins/witness/witness.cpp
@@ -537,6 +537,7 @@ void witness_plugin::start_mining(
              }
           }
        } );
+       thread_num++;
     }
 }
 


### PR DESCRIPTION
The nonce should be different for each thread, otherwise all threads are performing the exact same hash, which means effectively on a machine with N cores you were only actually performing 1 core's worth of work.
This should hopefully bring back some fairness in mining.

Since I'm giving up my unfair advantage, I hope this comes with a bug bounty from steemit and/or golos. Please PM 'penguin' in golos or steemit chat if so, so I can say where to issue it. :)