### PR TITLE
Fix required-participation in config_debug.ini

### DIFF
--- a/share/golosd/config/config_debug.ini
+++ b/share/golosd/config/config_debug.ini
@@ -68,7 +68,7 @@ history-per-size = 5760
 enable-stale-production = true
 
 # Percent of witnesses (0-99) that must be participating in order to produce blocks
-required-participation = false
+required-participation = 0
 
 # name of witness controlled by this node (e.g. initwitness )
 witness = "cyberfounder"


### PR DESCRIPTION
Fixes the following error:
testnet_1  | Error parsing command line: the argument ('false') for option 'required-participation' is invalid