### PR TITLE
Refactored get_account_reputations API method in follow plugin

### DIFF
--- a/plugins/follow/include/golos/plugins/follow/plugin.hpp
+++ b/plugins/follow/include/golos/plugins/follow/plugin.hpp
@@ -52,8 +52,7 @@ namespace golos {
                         (get_blog_authors))
 
                 std::vector<account_reputation> get_account_reputations_native(
-                        account_name_type account_lower_bound,
-                        uint32_t limit);
+                        std::vector < account_name_type > accounts );
 
                 plugin();
 

--- a/plugins/follow/plugin.cpp
+++ b/plugins/follow/plugin.cpp
@@ -627,7 +627,7 @@ namespace golos {
                     std::vector < account_name_type > accounts
                 ) {
 
-                FC_ASSERT(accounts.size() <= 1000, "Cannot retrieve more than 1000 account reputations at a time.");
+                FC_ASSERT(accounts.size() <= 100, "Cannot retrieve more than 100 account reputations at a time.");
 
                 const auto &acc_idx = database().get_index<account_index>().indices().get<by_name>();
                 const auto &rep_idx = database().get_index<reputation_index>().indices().get<by_account>();
@@ -646,7 +646,7 @@ namespace golos {
 
                         rep.account = accounts[i];
                         rep.reputation = 0;
-                        result.push_back( rep );
+                        result.push_back( std::move(rep) );
 
                         wlog("Follow plugin: No such account with name \"${name}\" in account index", ("name", accounts[i]) );
                         continue;
@@ -664,7 +664,7 @@ namespace golos {
                         rep.reputation = 0;
                     }
 
-                    result.push_back(rep);
+                    result.push_back( std::move(rep) );
                 }
                 return result;
             }

--- a/plugins/follow/plugin.cpp
+++ b/plugins/follow/plugin.cpp
@@ -638,23 +638,34 @@ namespace golos {
                 result.reserve(acc_count);
 
                 for (size_t i = 0; i < acc_count; i++) {
-                    auto acc_itr = acc_idx.lower_bound( accounts[i] );
-                    
-                    auto itr = rep_idx.find(acc_itr->name);
                     account_reputation rep;
+                    auto acc_itr = acc_idx.find( accounts[i] );
+
+                    // checking the presence of account with such name in database
+                    if ( acc_itr == acc_idx.end() ) {
+
+                        rep.account = accounts[i];
+                        rep.reputation = 0;
+                        result.push_back( rep );
+
+                        wlog("Follow plugin: No such account with name \"${name}\" in account index", ("name", accounts[i]) );
+                        continue;
+                    }
 
                     rep.account = acc_itr->name;
 
+                    auto itr = rep_idx.find(acc_itr->name);
+                    // same presence check in reputation idx
                     if ( itr != rep_idx.end() ) {
                         rep.reputation = itr->reputation;
                     }
                     else {
+                        wlog("Follow plugin: No such account with name \"${name}\" in reputation index", ("name", accounts[i]) );
                         rep.reputation = 0;
                     }
 
                     result.push_back(rep);
                 }
-
                 return result;
             }
 


### PR DESCRIPTION
`follow::get_account_reputations` has been changed. Now it takes a vector of account names and returns vector of reputations for every given account name. If it's not found then reputation is set by zero. 