### PR TITLE
Created empty API library for shared api_objects. #595

### DIFF
--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(api)
 add_subdirectory(chain)
 add_subdirectory(protocol)
 add_subdirectory(network)

--- a/libraries/api/CMakeLists.txt
+++ b/libraries/api/CMakeLists.txt
@@ -1,0 +1,37 @@
+set(CURRENT_TARGET api)
+
+list(APPEND CURRENT_TARGET_HEADERS
+)
+
+list(APPEND CURRENT_TARGET_SOURCES
+)
+
+if(BUILD_SHARED_LIBRARIES)
+    add_library(golos_${CURRENT_TARGET} SHARED
+        ${CURRENT_TARGET_HEADERS}
+        ${CURRENT_TARGET_SOURCES}
+    )
+else()
+    add_library(golos_${CURRENT_TARGET} STATIC
+        ${CURRENT_TARGET_HEADERS}
+        ${CURRENT_TARGET_SOURCES}
+    )
+endif()
+
+add_library(golos::${CURRENT_TARGET} ALIAS golos_${CURRENT_TARGET})
+set_property(TARGET golos_${CURRENT_TARGET} PROPERTY EXPORT_NAME ${CURRENT_TARGET})
+
+target_link_libraries(
+        golos_${CURRENT_TARGET}
+)
+
+target_include_directories(golos_${CURRENT_TARGET}
+        PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+install(TARGETS
+        golos_${CURRENT_TARGET}
+
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        )


### PR DESCRIPTION
Minor architectural change for future moving shared API objects to common `API` library. Nearest one such change is in issue #589 -- moving `extended_account` from `database_api` to `api` library to make it easy to share api object. 

Or maybe this pull request should be included into #589 issue code to prevent temporary cmake errors in `golos-v0.18.0` branch