### PR TITLE
Create missing account_metadata objects #599

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -2934,6 +2934,11 @@ namespace golos { namespace chain {
                 create<account_object>([&](account_object &a) {
                     a.name = STEEMIT_MINER_ACCOUNT;
                 });
+#ifndef IS_LOW_MEM
+                create<account_metadata_object>([&](account_metadata_object& m) {
+                    m.account = STEEMIT_MINER_ACCOUNT;
+                });
+#endif
                 create<account_authority_object>([&](account_authority_object &auth) {
                     auth.account = STEEMIT_MINER_ACCOUNT;
                     auth.owner.weight_threshold = 1;
@@ -2943,6 +2948,11 @@ namespace golos { namespace chain {
                 create<account_object>([&](account_object &a) {
                     a.name = STEEMIT_NULL_ACCOUNT;
                 });
+#ifndef IS_LOW_MEM
+                create<account_metadata_object>([&](account_metadata_object& m) {
+                    m.account = STEEMIT_NULL_ACCOUNT;
+                });
+#endif
                 create<account_authority_object>([&](account_authority_object &auth) {
                     auth.account = STEEMIT_NULL_ACCOUNT;
                     auth.owner.weight_threshold = 1;
@@ -2952,6 +2962,11 @@ namespace golos { namespace chain {
                 create<account_object>([&](account_object &a) {
                     a.name = STEEMIT_TEMP_ACCOUNT;
                 });
+#ifndef IS_LOW_MEM
+                create<account_metadata_object>([&](account_metadata_object& m) {
+                    m.account = STEEMIT_TEMP_ACCOUNT;
+                });
+#endif
                 create<account_authority_object>([&](account_authority_object &auth) {
                     auth.account = STEEMIT_TEMP_ACCOUNT;
                     auth.owner.weight_threshold = 0;
@@ -2959,25 +2974,26 @@ namespace golos { namespace chain {
                 });
 
                 for (int i = 0; i < STEEMIT_NUM_INIT_MINERS; ++i) {
+                    const auto& name = STEEMIT_INIT_MINER_NAME + (i ? fc::to_string(i) : std::string());
                     create<account_object>([&](account_object &a) {
-                        a.name = STEEMIT_INIT_MINER_NAME +
-                                 (i ? fc::to_string(i) : std::string());
+                        a.name = name;
                         a.memo_key = init_public_key;
                         a.balance = asset(i ? 0 : init_supply, STEEM_SYMBOL);
                     });
-
+#ifndef IS_LOW_MEM
+                    create<account_metadata_object>([&](account_metadata_object& m) {
+                        m.account = name;
+                    });
+#endif
                     create<account_authority_object>([&](account_authority_object &auth) {
-                        auth.account = STEEMIT_INIT_MINER_NAME +
-                                       (i ? fc::to_string(i) : std::string());
+                        auth.account = name;
                         auth.owner.add_authority(init_public_key, 1);
                         auth.owner.weight_threshold = 1;
                         auth.active = auth.owner;
                         auth.posting = auth.active;
                     });
-
                     create<witness_object>([&](witness_object &w) {
-                        w.owner = STEEMIT_INIT_MINER_NAME +
-                                  (i ? fc::to_string(i) : std::string());
+                        w.owner = name;
                         w.signing_key = init_public_key;
                         w.schedule = witness_object::miner;
                     });

--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -1658,12 +1658,12 @@ namespace golos { namespace chain {
                 }
             }
 
-            const auto &accounts_by_name = db.get_index<account_index>().indices().get<by_name>();
-
-            auto itr = accounts_by_name.find(o.get_worker_account());
+            const auto& name = o.get_worker_account();
+            const auto& accounts_by_name = db.get_index<account_index>().indices().get<by_name>();
+            auto itr = accounts_by_name.find(name);
             if (itr == accounts_by_name.end()) {
                 db.create<account_object>([&](account_object &acc) {
-                    acc.name = o.get_worker_account();
+                    acc.name = name;
                     acc.memo_key = o.work.worker;
                     acc.created = dgp.time;
                     acc.last_vote_time = dgp.time;
@@ -1674,17 +1674,18 @@ namespace golos { namespace chain {
                         acc.recovery_account = "";
                     } /// highest voted witness at time of recovery
                 });
+                store_account_json_metadata(db, name, "");
 
                 db.create<account_authority_object>([&](account_authority_object &auth) {
-                    auth.account = o.get_worker_account();
+                    auth.account = name;
                     auth.owner = authority(1, o.work.worker, 1);
                     auth.active = auth.owner;
                     auth.posting = auth.owner;
                 });
             }
 
-            const auto &worker_account = db.get_account(o.get_worker_account()); // verify it exists
-            const auto &worker_auth = db.get<account_authority_object, by_account>(o.get_worker_account());
+            const auto &worker_account = db.get_account(name); // verify it exists
+            const auto &worker_auth = db.get<account_authority_object, by_account>(name);
             FC_ASSERT(worker_auth.active.num_auths() ==
                       1, "Miners can only have one key authority. ${a}", ("a", worker_auth.active));
             FC_ASSERT(worker_auth.active.key_auths.size() ==
@@ -1719,7 +1720,7 @@ namespace golos { namespace chain {
                 });
             } else {
                 db.create<witness_object>([&](witness_object &w) {
-                    w.owner = o.get_worker_account();
+                    w.owner = name;
                     w.props = o.props;
                     w.signing_key = o.work.worker;
                     w.pow_worker = dgp.total_pow;
@@ -1793,6 +1794,7 @@ namespace golos { namespace chain {
                     acc.last_vote_time = dgp.time;
                     acc.recovery_account = ""; /// highest voted witness at time of recovery
                 });
+                store_account_json_metadata(db, worker_account, "");
 
                 db.create<account_authority_object>([&](account_authority_object &auth) {
                     auth.account = worker_account;

--- a/libraries/protocol/include/golos/protocol/config.hpp
+++ b/libraries/protocol/include/golos/protocol/config.hpp
@@ -62,9 +62,9 @@
 #define STEEMIT_VESTING_WITHDRAW_INTERVALS      13
 #define STEEMIT_VESTING_WITHDRAW_INTERVAL_SECONDS (60*60*24*7) // 1 week per interval
 #define STEEMIT_MAX_WITHDRAW_ROUTES             10
-#define STEEMIT_SAVINGS_WITHDRAW_TIME            (fc::days(3))
+#define STEEMIT_SAVINGS_WITHDRAW_TIME           (fc::days(3))
 #define STEEMIT_SAVINGS_WITHDRAW_REQUEST_LIMIT  100
-#define STEEMIT_VOTE_REGENERATION_SECONDS       (5*60*60*24) // 5 day
+#define STEEMIT_VOTE_REGENERATION_SECONDS       (5*60*60*24) // 5 days
 #define STEEMIT_MAX_VOTE_CHANGES                5
 #define STEEMIT_UPVOTE_LOCKOUT                  (fc::minutes(1))
 #define STEEMIT_REVERSE_AUCTION_WINDOW_SECONDS  (60*30) /// 30 minutes
@@ -230,7 +230,7 @@
 
 #define STEEMIT_GENESIS_TIME                    (fc::time_point_sec(1476788400))
 #define STEEMIT_MINING_TIME                     (fc::time_point_sec(1458838800))
-#define STEEMIT_CASHOUT_WINDOW_SECONDS          (60*60*24*7)  // 1 weak
+#define STEEMIT_CASHOUT_WINDOW_SECONDS          (60*60*24*7)  // 1 week
 #define STEEMIT_CASHOUT_WINDOW_SECONDS_PRE_HF12 (60*60*24)    // 1 day
 #define STEEMIT_CASHOUT_WINDOW_SECONDS_PRE_HF17 STEEMIT_CASHOUT_WINDOW_SECONDS_PRE_HF12
 #define STEEMIT_SECOND_CASHOUT_WINDOW           (60*60*24*30) /// 30 days
@@ -267,9 +267,9 @@
 #define STEEMIT_VESTING_WITHDRAW_INTERVALS      13
 #define STEEMIT_VESTING_WITHDRAW_INTERVAL_SECONDS (60*60*24*7) // 1 week per interval
 #define STEEMIT_MAX_WITHDRAW_ROUTES             10
-#define STEEMIT_SAVINGS_WITHDRAW_TIME            (fc::days(3))
+#define STEEMIT_SAVINGS_WITHDRAW_TIME           (fc::days(3))
 #define STEEMIT_SAVINGS_WITHDRAW_REQUEST_LIMIT  100
-#define STEEMIT_VOTE_REGENERATION_SECONDS       (5*60*60*24) // 5 day
+#define STEEMIT_VOTE_REGENERATION_SECONDS       (5*60*60*24) // 5 days
 #define STEEMIT_MAX_VOTE_CHANGES                5
 #define STEEMIT_UPVOTE_LOCKOUT                  (fc::minutes(1))
 #define STEEMIT_REVERSE_AUCTION_WINDOW_SECONDS  (60*30) /// 30 minutes

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -6297,7 +6297,7 @@ BOOST_FIXTURE_TEST_SUITE(operation_tests, clean_database_fixture)
 
             BOOST_TEST_MESSAGE("--- Test failure when GESTS are powering down");
             withdraw_vesting_operation withdraw;
-            withdraw.account = "alice";	
+            withdraw.account = "alice";
             withdraw.vesting_shares = db->get_account("alice").vesting_shares;
 
             account_create_with_delegation_operation op;


### PR DESCRIPTION
1. Add `account_metadata` object while create accounts in `init_genesis`
2. Add `account_metadata` object to account created with mining
3. Fix some typos

Fixes #599 