### PR TITLE
 Add ability to get received delegations of account #592

### DIFF
--- a/libraries/chain/include/golos/chain/account_object.hpp
+++ b/libraries/chain/include/golos/chain/account_object.hpp
@@ -430,6 +430,7 @@ namespace golos { namespace chain {
         account_bandwidth_index;
 
         struct by_delegation;
+        struct by_received;
 
         using vesting_delegation_index = multi_index_container<
             vesting_delegation_object,
@@ -443,6 +444,15 @@ namespace golos { namespace chain {
                         vesting_delegation_object,
                         member<vesting_delegation_object, account_name_type, &vesting_delegation_object::delegator>,
                         member<vesting_delegation_object, account_name_type, &vesting_delegation_object::delegatee>
+                    >,
+                    composite_key_compare<protocol::string_less, protocol::string_less>
+                >,
+                ordered_unique<
+                    tag<by_received>,
+                    composite_key<
+                        vesting_delegation_object,
+                        member<vesting_delegation_object, account_name_type, &vesting_delegation_object::delegatee>,
+                        member<vesting_delegation_object, account_name_type, &vesting_delegation_object::delegator>
                     >,
                     composite_key_compare<protocol::string_less, protocol::string_less>
                 >
@@ -536,8 +546,8 @@ namespace golos { namespace chain {
         allocator<change_recovery_account_request_object>
         >
         change_recovery_account_request_index;
-    }
-}
+
+} } // golos::chain
 
 FC_REFLECT((golos::chain::account_object),
         (id)(name)(memo_key)(proxy)(last_account_update)

--- a/libraries/chain/include/golos/chain/account_object.hpp
+++ b/libraries/chain/include/golos/chain/account_object.hpp
@@ -15,539 +15,540 @@
 
 namespace golos { namespace chain {
 
-        using golos::protocol::authority;
+using golos::protocol::authority;
 
-        class account_object
-                : public object<account_object_type, account_object> {
-        public:
-            account_object() = delete;
+class account_object
+        : public object<account_object_type, account_object> {
+public:
+    account_object() = delete;
 
-            template<typename Constructor, typename Allocator>
-            account_object(Constructor&& c, allocator<Allocator> a) {
-                c(*this);
-            };
+    template<typename Constructor, typename Allocator>
+    account_object(Constructor&& c, allocator<Allocator> a) {
+        c(*this);
+    };
 
-            id_type id;
+    id_type id;
 
-            account_name_type name;
-            public_key_type memo_key;
-            account_name_type proxy;
+    account_name_type name;
+    public_key_type memo_key;
+    account_name_type proxy;
 
-            time_point_sec last_account_update;
+    time_point_sec last_account_update;
 
-            time_point_sec created;
-            bool mined = true;
-            bool owner_challenged = false;
-            bool active_challenged = false;
-            time_point_sec last_owner_proved = time_point_sec::min();
-            time_point_sec last_active_proved = time_point_sec::min();
-            account_name_type recovery_account;
-            account_name_type reset_account = STEEMIT_NULL_ACCOUNT;
-            time_point_sec last_account_recovery;
-            uint32_t comment_count = 0;
-            uint32_t lifetime_vote_count = 0;
-            uint32_t post_count = 0;
+    time_point_sec created;
+    bool mined = true;
+    bool owner_challenged = false;
+    bool active_challenged = false;
+    time_point_sec last_owner_proved = time_point_sec::min();
+    time_point_sec last_active_proved = time_point_sec::min();
+    account_name_type recovery_account;
+    account_name_type reset_account = STEEMIT_NULL_ACCOUNT;
+    time_point_sec last_account_recovery;
+    uint32_t comment_count = 0;
+    uint32_t lifetime_vote_count = 0;
+    uint32_t post_count = 0;
 
-            bool can_vote = true;
-            uint16_t voting_power = STEEMIT_100_PERCENT;   ///< current voting power of this account, it falls after every vote
-            time_point_sec last_vote_time; ///< used to increase the voting power of this account the longer it goes without voting.
+    bool can_vote = true;
+    uint16_t voting_power = STEEMIT_100_PERCENT;   ///< current voting power of this account, it falls after every vote
+    time_point_sec last_vote_time; ///< used to increase the voting power of this account the longer it goes without voting.
 
-            asset balance = asset(0, STEEM_SYMBOL);  ///< total liquid shares held by this account
-            asset savings_balance = asset(0, STEEM_SYMBOL);  ///< total liquid shares held by this account
+    asset balance = asset(0, STEEM_SYMBOL);  ///< total liquid shares held by this account
+    asset savings_balance = asset(0, STEEM_SYMBOL);  ///< total liquid shares held by this account
 
-            /**
-             *  SBD Deposits pay interest based upon the interest rate set by witnesses. The purpose of these
-             *  fields is to track the total (time * sbd_balance) that it is held. Then at the appointed time
-             *  interest can be paid using the following equation:
-             *
-             *  interest = interest_rate * sbd_seconds / seconds_per_year
-             *
-             *  Every time the sbd_balance is updated the sbd_seconds is also updated. If at least
-             *  STEEMIT_MIN_COMPOUNDING_INTERVAL_SECONDS has past since sbd_last_interest_payment then
-             *  interest is added to sbd_balance.
-             *
-             *  @defgroup sbd_data SBD Balance Data
-             */
-            ///@{
-            asset sbd_balance = asset(0, SBD_SYMBOL); /// total sbd balance
-            uint128_t sbd_seconds; ///< total sbd * how long it has been hel
-            time_point_sec sbd_seconds_last_update; ///< the last time the sbd_seconds was updated
-            time_point_sec sbd_last_interest_payment; ///< used to pay interest at most once per month
+    /**
+     *  SBD Deposits pay interest based upon the interest rate set by witnesses. The purpose of these
+     *  fields is to track the total (time * sbd_balance) that it is held. Then at the appointed time
+     *  interest can be paid using the following equation:
+     *
+     *  interest = interest_rate * sbd_seconds / seconds_per_year
+     *
+     *  Every time the sbd_balance is updated the sbd_seconds is also updated. If at least
+     *  STEEMIT_MIN_COMPOUNDING_INTERVAL_SECONDS has past since sbd_last_interest_payment then
+     *  interest is added to sbd_balance.
+     *
+     *  @defgroup sbd_data SBD Balance Data
+     */
+    ///@{
+    asset sbd_balance = asset(0, SBD_SYMBOL); /// total sbd balance
+    uint128_t sbd_seconds; ///< total sbd * how long it has been hel
+    time_point_sec sbd_seconds_last_update; ///< the last time the sbd_seconds was updated
+    time_point_sec sbd_last_interest_payment; ///< used to pay interest at most once per month
 
 
-            asset savings_sbd_balance = asset(0, SBD_SYMBOL); /// total sbd balance
-            uint128_t savings_sbd_seconds; ///< total sbd * how long it has been hel
-            time_point_sec savings_sbd_seconds_last_update; ///< the last time the sbd_seconds was updated
-            time_point_sec savings_sbd_last_interest_payment; ///< used to pay interest at most once per month
+    asset savings_sbd_balance = asset(0, SBD_SYMBOL); /// total sbd balance
+    uint128_t savings_sbd_seconds; ///< total sbd * how long it has been hel
+    time_point_sec savings_sbd_seconds_last_update; ///< the last time the sbd_seconds was updated
+    time_point_sec savings_sbd_last_interest_payment; ///< used to pay interest at most once per month
 
-            uint8_t savings_withdraw_requests = 0;
-            ///@}
+    uint8_t savings_withdraw_requests = 0;
+    ///@}
 
-            share_type curation_rewards = 0;
-            share_type posting_rewards = 0;
+    share_type curation_rewards = 0;
+    share_type posting_rewards = 0;
 
-            asset vesting_shares = asset(0, VESTS_SYMBOL); ///< total vesting shares held by this account, controls its voting power
-            asset delegated_vesting_shares = asset(0, VESTS_SYMBOL); ///<
-            asset received_vesting_shares = asset(0, VESTS_SYMBOL); ///<
+    asset vesting_shares = asset(0, VESTS_SYMBOL); ///< total vesting shares held by this account, controls its voting power
+    asset delegated_vesting_shares = asset(0, VESTS_SYMBOL); ///<
+    asset received_vesting_shares = asset(0, VESTS_SYMBOL); ///<
 
-            asset vesting_withdraw_rate = asset(0, VESTS_SYMBOL); ///< at the time this is updated it can be at most vesting_shares/104
-            time_point_sec next_vesting_withdrawal = fc::time_point_sec::maximum(); ///< after every withdrawal this is incremented by 1 week
-            share_type withdrawn = 0; /// Track how many shares have been withdrawn
-            share_type to_withdraw = 0; /// Might be able to look this up with operation history.
-            uint16_t withdraw_routes = 0;
+    asset vesting_withdraw_rate = asset(0, VESTS_SYMBOL); ///< at the time this is updated it can be at most vesting_shares/104
+    time_point_sec next_vesting_withdrawal = fc::time_point_sec::maximum(); ///< after every withdrawal this is incremented by 1 week
+    share_type withdrawn = 0; /// Track how many shares have been withdrawn
+    share_type to_withdraw = 0; /// Might be able to look this up with operation history.
+    uint16_t withdraw_routes = 0;
 
-            fc::array<share_type, STEEMIT_MAX_PROXY_RECURSION_DEPTH> proxied_vsf_votes;// = std::vector<share_type>( STEEMIT_MAX_PROXY_RECURSION_DEPTH, 0 ); ///< the total VFS votes proxied to this account
+    fc::array<share_type, STEEMIT_MAX_PROXY_RECURSION_DEPTH> proxied_vsf_votes;// = std::vector<share_type>( STEEMIT_MAX_PROXY_RECURSION_DEPTH, 0 ); ///< the total VFS votes proxied to this account
 
-            uint16_t witnesses_voted_for = 0;
+    uint16_t witnesses_voted_for = 0;
 
-            time_point_sec last_post;
+    time_point_sec last_post;
 
-            /// This function should be used only when the account votes for a witness directly
-            share_type witness_vote_weight() const {
-                return std::accumulate(proxied_vsf_votes.begin(),
-                        proxied_vsf_votes.end(),
-                        vesting_shares.amount);
-            }
+    /// This function should be used only when the account votes for a witness directly
+    share_type witness_vote_weight() const {
+        return std::accumulate(proxied_vsf_votes.begin(),
+                proxied_vsf_votes.end(),
+                vesting_shares.amount);
+    }
 
-            share_type proxied_vsf_votes_total() const {
-                return std::accumulate(proxied_vsf_votes.begin(),
-                        proxied_vsf_votes.end(),
-                        share_type());
-            }
+    share_type proxied_vsf_votes_total() const {
+        return std::accumulate(proxied_vsf_votes.begin(),
+                proxied_vsf_votes.end(),
+                share_type());
+    }
 
-            /// vesting shares used in voting and bandwidth calculation
-            asset effective_vesting_shares() const {
-                return vesting_shares - delegated_vesting_shares + received_vesting_shares;
-            }
+    /// vesting shares used in voting and bandwidth calculation
+    asset effective_vesting_shares() const {
+        return vesting_shares - delegated_vesting_shares + received_vesting_shares;
+    }
 
-            /// vesting shares, which can be used for delegation (incl. create account) and withdraw operations
-            asset available_vesting_shares(bool consider_withdrawal = false) const {
-                auto have = vesting_shares - delegated_vesting_shares;
-                return consider_withdrawal ? have - asset(to_withdraw - withdrawn, VESTS_SYMBOL) : have;
-            }
-        };
+    /// vesting shares, which can be used for delegation (incl. create account) and withdraw operations
+    asset available_vesting_shares(bool consider_withdrawal = false) const {
+        auto have = vesting_shares - delegated_vesting_shares;
+        return consider_withdrawal ? have - asset(to_withdraw - withdrawn, VESTS_SYMBOL) : have;
+    }
+};
 
-        class account_authority_object
-                : public object<account_authority_object_type, account_authority_object> {
-        public:
-            account_authority_object() = delete;
+class account_authority_object
+        : public object<account_authority_object_type, account_authority_object> {
+public:
+    account_authority_object() = delete;
 
-            template<typename Constructor, typename Allocator>
-            account_authority_object(Constructor &&c, allocator<Allocator> a)
-                    : owner(a), active(a), posting(a) {
-                c(*this);
-            }
+    template<typename Constructor, typename Allocator>
+    account_authority_object(Constructor &&c, allocator<Allocator> a)
+            : owner(a), active(a), posting(a) {
+        c(*this);
+    }
 
-            id_type id;
+    id_type id;
 
-            account_name_type account;
+    account_name_type account;
 
-            shared_authority owner;   ///< used for backup control, can set owner or active
-            shared_authority active;  ///< used for all monetary operations, can set active or posting
-            shared_authority posting; ///< used for voting and posting
+    shared_authority owner;   ///< used for backup control, can set owner or active
+    shared_authority active;  ///< used for all monetary operations, can set active or posting
+    shared_authority posting; ///< used for voting and posting
 
-            time_point_sec last_owner_update;
-        };
+    time_point_sec last_owner_update;
+};
 
-        class account_bandwidth_object
-                : public object<account_bandwidth_object_type, account_bandwidth_object> {
-        public:
-            template<typename Constructor, typename Allocator>
-            account_bandwidth_object(Constructor &&c, allocator<Allocator> a) {
-                c(*this);
-            }
+class account_bandwidth_object
+        : public object<account_bandwidth_object_type, account_bandwidth_object> {
+public:
+    template<typename Constructor, typename Allocator>
+    account_bandwidth_object(Constructor &&c, allocator<Allocator> a) {
+        c(*this);
+    }
 
-            account_bandwidth_object() {
-            }
+    account_bandwidth_object() {
+    }
 
-            id_type id;
+    id_type id;
 
-            account_name_type account;
-            bandwidth_type type;
-            share_type average_bandwidth;
-            share_type lifetime_bandwidth;
-            time_point_sec last_bandwidth_update;
-        };
+    account_name_type account;
+    bandwidth_type type;
+    share_type average_bandwidth;
+    share_type lifetime_bandwidth;
+    time_point_sec last_bandwidth_update;
+};
 
-        class account_metadata_object : public object<account_metadata_object_type, account_metadata_object> {
-        public:
-            account_metadata_object() = delete;
+class account_metadata_object : public object<account_metadata_object_type, account_metadata_object> {
+public:
+    account_metadata_object() = delete;
 
-            template<typename Constructor, typename Allocator>
-            account_metadata_object(Constructor&& c, allocator<Allocator> a) : json_metadata(a) {
-                c(*this);
-            }
+    template<typename Constructor, typename Allocator>
+    account_metadata_object(Constructor&& c, allocator<Allocator> a) : json_metadata(a) {
+        c(*this);
+    }
 
-            id_type id;
-            account_name_type account;
-            shared_string json_metadata;
-        };
+    id_type id;
+    account_name_type account;
+    shared_string json_metadata;
+};
 
-        class vesting_delegation_object: public object<vesting_delegation_object_type, vesting_delegation_object> {
-        public:
-            template<typename Constructor, typename Allocator>
-            vesting_delegation_object(Constructor&& c, allocator<Allocator> a) {
-                c(*this);
-            }
+class vesting_delegation_object: public object<vesting_delegation_object_type, vesting_delegation_object> {
+public:
+    template<typename Constructor, typename Allocator>
+    vesting_delegation_object(Constructor&& c, allocator<Allocator> a) {
+        c(*this);
+    }
 
-            vesting_delegation_object() {
-            }
+    vesting_delegation_object() {
+    }
 
-            id_type id;
-            account_name_type delegator;
-            account_name_type delegatee;
-            asset vesting_shares;
-            time_point_sec min_delegation_time;
-        };
+    id_type id;
+    account_name_type delegator;
+    account_name_type delegatee;
+    asset vesting_shares;
+    time_point_sec min_delegation_time;
+};
 
-        class vesting_delegation_expiration_object: public object<vesting_delegation_expiration_object_type, vesting_delegation_expiration_object> {
-        public:
-            template<typename Constructor, typename Allocator>
-            vesting_delegation_expiration_object(Constructor&& c, allocator<Allocator> a) {
-                c(*this);
-            }
+class vesting_delegation_expiration_object: public object<vesting_delegation_expiration_object_type, vesting_delegation_expiration_object> {
+public:
+    template<typename Constructor, typename Allocator>
+    vesting_delegation_expiration_object(Constructor&& c, allocator<Allocator> a) {
+        c(*this);
+    }
 
-            vesting_delegation_expiration_object() {
-            }
+    vesting_delegation_expiration_object() {
+    }
 
-            id_type id;
-            account_name_type delegator;
-            asset vesting_shares;
-            time_point_sec expiration;
-        };
+    id_type id;
+    account_name_type delegator;
+    asset vesting_shares;
+    time_point_sec expiration;
+};
 
-        class owner_authority_history_object
-                : public object<owner_authority_history_object_type, owner_authority_history_object> {
-        public:
-            owner_authority_history_object() = delete;
+class owner_authority_history_object
+        : public object<owner_authority_history_object_type, owner_authority_history_object> {
+public:
+    owner_authority_history_object() = delete;
 
-            template<typename Constructor, typename Allocator>
-            owner_authority_history_object(Constructor &&c, allocator<Allocator> a)
-                    :previous_owner_authority(shared_authority::allocator_type(a.get_segment_manager())) {
-                c(*this);
-            }
+    template<typename Constructor, typename Allocator>
+    owner_authority_history_object(Constructor &&c, allocator<Allocator> a)
+            :previous_owner_authority(shared_authority::allocator_type(a.get_segment_manager())) {
+        c(*this);
+    }
 
-            id_type id;
+    id_type id;
 
-            account_name_type account;
-            shared_authority previous_owner_authority;
-            time_point_sec last_valid_time;
-        };
+    account_name_type account;
+    shared_authority previous_owner_authority;
+    time_point_sec last_valid_time;
+};
 
-        class account_recovery_request_object
-                : public object<account_recovery_request_object_type, account_recovery_request_object> {
-        public:
-            account_recovery_request_object() = delete;
+class account_recovery_request_object
+        : public object<account_recovery_request_object_type, account_recovery_request_object> {
+public:
+    account_recovery_request_object() = delete;
 
-            template<typename Constructor, typename Allocator>
-            account_recovery_request_object(Constructor &&c, allocator<Allocator> a)
-                    :new_owner_authority(shared_authority::allocator_type(a.get_segment_manager())) {
-                c(*this);
-            }
+    template<typename Constructor, typename Allocator>
+    account_recovery_request_object(Constructor &&c, allocator<Allocator> a)
+            :new_owner_authority(shared_authority::allocator_type(a.get_segment_manager())) {
+        c(*this);
+    }
 
-            id_type id;
+    id_type id;
 
-            account_name_type account_to_recover;
-            shared_authority new_owner_authority;
-            time_point_sec expires;
-        };
+    account_name_type account_to_recover;
+    shared_authority new_owner_authority;
+    time_point_sec expires;
+};
 
-        class change_recovery_account_request_object
-                : public object<change_recovery_account_request_object_type, change_recovery_account_request_object> {
-        public:
-            template<typename Constructor, typename Allocator>
-            change_recovery_account_request_object(Constructor &&c, allocator<Allocator> a) {
-                c(*this);
-            }
+class change_recovery_account_request_object
+        : public object<change_recovery_account_request_object_type, change_recovery_account_request_object> {
+public:
+    template<typename Constructor, typename Allocator>
+    change_recovery_account_request_object(Constructor &&c, allocator<Allocator> a) {
+        c(*this);
+    }
 
-            id_type id;
+    id_type id;
 
-            account_name_type account_to_recover;
-            account_name_type recovery_account;
-            time_point_sec effective_on;
-        };
+    account_name_type account_to_recover;
+    account_name_type recovery_account;
+    time_point_sec effective_on;
+};
 
-        struct by_name;
-        struct by_proxy;
-        struct by_last_post;
-        struct by_next_vesting_withdrawal;
-        struct by_steem_balance;
-        struct by_smp_balance;
-        struct by_smd_balance;
-        struct by_post_count;
-        struct by_vote_count;
+struct by_name;
+struct by_proxy;
+struct by_last_post;
+struct by_next_vesting_withdrawal;
+struct by_steem_balance;
+struct by_smp_balance;
+struct by_smd_balance;
+struct by_post_count;
+struct by_vote_count;
 
-        /**
-         * @ingroup object_index
-         */
-        typedef multi_index_container<
-                account_object,
-                indexed_by<
-                        ordered_unique<tag<by_id>,
-                                member<account_object, account_id_type, &account_object::id>>,
-                        ordered_unique<tag<by_name>,
-                                member<account_object, account_name_type, &account_object::name>,
-                                protocol::string_less>,
-                        ordered_unique<tag<by_proxy>,
-                                composite_key < account_object,
-                                member<account_object, account_name_type, &account_object::proxy>,
-                                member<account_object, account_id_type, &account_object::id>
-                        > /// composite key by proxy
-                >,
-                ordered_unique<tag<by_next_vesting_withdrawal>,
+/**
+ * @ingroup object_index
+ */
+typedef multi_index_container<
+        account_object,
+        indexed_by<
+                ordered_unique<tag<by_id>,
+                        member<account_object, account_id_type, &account_object::id>>,
+                ordered_unique<tag<by_name>,
+                        member<account_object, account_name_type, &account_object::name>,
+                        protocol::string_less>,
+                ordered_unique<tag<by_proxy>,
                         composite_key < account_object,
-                        member<account_object, time_point_sec, &account_object::next_vesting_withdrawal>,
+                        member<account_object, account_name_type, &account_object::proxy>,
                         member<account_object, account_id_type, &account_object::id>
-                > /// composite key by_next_vesting_withdrawal
+                > /// composite key by proxy
         >,
-        ordered_unique<tag<by_last_post>,
+        ordered_unique<tag<by_next_vesting_withdrawal>,
                 composite_key < account_object,
-                member<account_object, time_point_sec, &account_object::last_post>,
+                member<account_object, time_point_sec, &account_object::next_vesting_withdrawal>,
                 member<account_object, account_id_type, &account_object::id>
-        >,
-        composite_key_compare <std::greater<time_point_sec>, std::less<account_id_type>>
-        >,
-        ordered_unique<tag<by_steem_balance>,
-                composite_key < account_object,
-                member<account_object, asset, &account_object::balance>,
-                member<account_object, account_id_type, &account_object::id>
-        >,
-        composite_key_compare <std::greater<asset>, std::less<account_id_type>>
-        >,
-        ordered_unique<tag<by_smp_balance>,
-                composite_key < account_object,
-                member<account_object, asset, &account_object::vesting_shares>,
-                member<account_object, account_id_type, &account_object::id>
-        >,
-        composite_key_compare <std::greater<asset>, std::less<account_id_type>>
-        >,
-        ordered_unique<tag<by_smd_balance>,
-                composite_key < account_object,
-                member<account_object, asset, &account_object::sbd_balance>,
-                member<account_object, account_id_type, &account_object::id>
-        >,
-        composite_key_compare <std::greater<asset>, std::less<account_id_type>>
-        >,
-        ordered_unique<tag<by_post_count>,
-                composite_key < account_object,
-                member<account_object, uint32_t, &account_object::post_count>,
-                member<account_object, account_id_type, &account_object::id>
-        >,
-        composite_key_compare <std::greater<uint32_t>, std::less<account_id_type>>
-        >,
-        ordered_unique<tag<by_vote_count>,
-                composite_key < account_object,
-                member<account_object, uint32_t, &account_object::lifetime_vote_count>,
-                member<account_object, account_id_type, &account_object::id>
-        >,
-        composite_key_compare <std::greater<uint32_t>, std::less<account_id_type>>
-        >
-        >,
-        allocator<account_object>
-        >
-        account_index;
+        > /// composite key by_next_vesting_withdrawal
+>,
+ordered_unique<tag<by_last_post>,
+        composite_key < account_object,
+        member<account_object, time_point_sec, &account_object::last_post>,
+        member<account_object, account_id_type, &account_object::id>
+>,
+composite_key_compare <std::greater<time_point_sec>, std::less<account_id_type>>
+>,
+ordered_unique<tag<by_steem_balance>,
+        composite_key < account_object,
+        member<account_object, asset, &account_object::balance>,
+        member<account_object, account_id_type, &account_object::id>
+>,
+composite_key_compare <std::greater<asset>, std::less<account_id_type>>
+>,
+ordered_unique<tag<by_smp_balance>,
+        composite_key < account_object,
+        member<account_object, asset, &account_object::vesting_shares>,
+        member<account_object, account_id_type, &account_object::id>
+>,
+composite_key_compare <std::greater<asset>, std::less<account_id_type>>
+>,
+ordered_unique<tag<by_smd_balance>,
+        composite_key < account_object,
+        member<account_object, asset, &account_object::sbd_balance>,
+        member<account_object, account_id_type, &account_object::id>
+>,
+composite_key_compare <std::greater<asset>, std::less<account_id_type>>
+>,
+ordered_unique<tag<by_post_count>,
+        composite_key < account_object,
+        member<account_object, uint32_t, &account_object::post_count>,
+        member<account_object, account_id_type, &account_object::id>
+>,
+composite_key_compare <std::greater<uint32_t>, std::less<account_id_type>>
+>,
+ordered_unique<tag<by_vote_count>,
+        composite_key < account_object,
+        member<account_object, uint32_t, &account_object::lifetime_vote_count>,
+        member<account_object, account_id_type, &account_object::id>
+>,
+composite_key_compare <std::greater<uint32_t>, std::less<account_id_type>>
+>
+>,
+allocator<account_object>
+>
+account_index;
 
-        struct by_account;
-        struct by_last_valid;
+struct by_account;
+struct by_last_valid;
 
-        typedef multi_index_container<
-                owner_authority_history_object,
-                indexed_by<
-                        ordered_unique<tag<by_id>,
-                                member<owner_authority_history_object, owner_authority_history_id_type, &owner_authority_history_object::id>>,
-                        ordered_unique<tag<by_account>,
-                                composite_key < owner_authority_history_object,
-                                member<owner_authority_history_object, account_name_type, &owner_authority_history_object::account>,
-                                member<owner_authority_history_object, time_point_sec, &owner_authority_history_object::last_valid_time>,
-                                member<owner_authority_history_object, owner_authority_history_id_type, &owner_authority_history_object::id>
-                        >,
-                        composite_key_compare <
-                        std::less<account_name_type>, std::less<time_point_sec>, std::less<owner_authority_history_id_type>>
-        >
-        >,
-        allocator<owner_authority_history_object>
-        >
-        owner_authority_history_index;
-
-
-        using account_metadata_index = multi_index_container<
-            account_metadata_object,
-            indexed_by<
-                ordered_unique<
-                    tag<by_id>, member<account_metadata_object, account_metadata_id_type, &account_metadata_object::id>
+typedef multi_index_container<
+        owner_authority_history_object,
+        indexed_by<
+                ordered_unique<tag<by_id>,
+                        member<owner_authority_history_object, owner_authority_history_id_type, &owner_authority_history_object::id>>,
+                ordered_unique<tag<by_account>,
+                        composite_key < owner_authority_history_object,
+                        member<owner_authority_history_object, account_name_type, &owner_authority_history_object::account>,
+                        member<owner_authority_history_object, time_point_sec, &owner_authority_history_object::last_valid_time>,
+                        member<owner_authority_history_object, owner_authority_history_id_type, &owner_authority_history_object::id>
                 >,
-                ordered_unique<
-                    tag<by_account>, member<account_metadata_object, account_name_type, &account_metadata_object::account>
-                >
-            >,
-            allocator<account_metadata_object>
-        >;
+                composite_key_compare <
+                std::less<account_name_type>, std::less<time_point_sec>, std::less<owner_authority_history_id_type>>
+>
+>,
+allocator<owner_authority_history_object>
+>
+owner_authority_history_index;
 
-        struct by_last_owner_update;
 
-        typedef multi_index_container<
-                account_authority_object,
-                indexed_by<
-                        ordered_unique<tag<by_id>,
-                                member<account_authority_object, account_authority_id_type, &account_authority_object::id>>,
-                        ordered_unique<tag<by_account>,
-                                composite_key < account_authority_object,
-                                member<account_authority_object, account_name_type, &account_authority_object::account>,
-                                member<account_authority_object, account_authority_id_type, &account_authority_object::id>
-                        >,
-                        composite_key_compare <
-                        std::less<account_name_type>, std::less<account_authority_id_type>>
+using account_metadata_index = multi_index_container<
+    account_metadata_object,
+    indexed_by<
+        ordered_unique<
+            tag<by_id>, member<account_metadata_object, account_metadata_id_type, &account_metadata_object::id>
         >,
-        ordered_unique<tag<by_last_owner_update>,
-                composite_key < account_authority_object,
-                member<account_authority_object, time_point_sec, &account_authority_object::last_owner_update>,
-                member<account_authority_object, account_authority_id_type, &account_authority_object::id>
-        >,
-        composite_key_compare <std::greater<time_point_sec>, std::less<account_authority_id_type>>
+        ordered_unique<
+            tag<by_account>, member<account_metadata_object, account_name_type, &account_metadata_object::account>
         >
-        >,
-        allocator<account_authority_object>
-        >
-        account_authority_index;
+    >,
+    allocator<account_metadata_object>
+>;
 
+struct by_last_owner_update;
 
-        struct by_account_bandwidth_type;
-
-        typedef multi_index_container<
-                account_bandwidth_object,
-                indexed_by<
-                        ordered_unique<tag<by_id>,
-                                member<account_bandwidth_object, account_bandwidth_id_type, &account_bandwidth_object::id>>,
-                        ordered_unique<tag<by_account_bandwidth_type>,
-                                composite_key < account_bandwidth_object,
-                                member<account_bandwidth_object, account_name_type, &account_bandwidth_object::account>,
-                                member<account_bandwidth_object, bandwidth_type, &account_bandwidth_object::type>
-                        >
-                >
-        >,
-        allocator<account_bandwidth_object>
-        >
-        account_bandwidth_index;
-
-        struct by_delegation;
-        struct by_received;
-
-        using vesting_delegation_index = multi_index_container<
-            vesting_delegation_object,
-            indexed_by<
-                ordered_unique<
-                    tag<by_id>,
-                    member<vesting_delegation_object, vesting_delegation_id_type, &vesting_delegation_object::id>>,
-                ordered_unique<
-                    tag<by_delegation>,
-                    composite_key<
-                        vesting_delegation_object,
-                        member<vesting_delegation_object, account_name_type, &vesting_delegation_object::delegator>,
-                        member<vesting_delegation_object, account_name_type, &vesting_delegation_object::delegatee>
-                    >,
-                    composite_key_compare<protocol::string_less, protocol::string_less>
+typedef multi_index_container<
+        account_authority_object,
+        indexed_by<
+                ordered_unique<tag<by_id>,
+                        member<account_authority_object, account_authority_id_type, &account_authority_object::id>>,
+                ordered_unique<tag<by_account>,
+                        composite_key < account_authority_object,
+                        member<account_authority_object, account_name_type, &account_authority_object::account>,
+                        member<account_authority_object, account_authority_id_type, &account_authority_object::id>
                 >,
-                ordered_unique<
-                    tag<by_received>,
-                    composite_key<
-                        vesting_delegation_object,
-                        member<vesting_delegation_object, account_name_type, &vesting_delegation_object::delegatee>,
-                        member<vesting_delegation_object, account_name_type, &vesting_delegation_object::delegator>
-                    >,
-                    composite_key_compare<protocol::string_less, protocol::string_less>
+                composite_key_compare <
+                std::less<account_name_type>, std::less<account_authority_id_type>>
+>,
+ordered_unique<tag<by_last_owner_update>,
+        composite_key < account_authority_object,
+        member<account_authority_object, time_point_sec, &account_authority_object::last_owner_update>,
+        member<account_authority_object, account_authority_id_type, &account_authority_object::id>
+>,
+composite_key_compare <std::greater<time_point_sec>, std::less<account_authority_id_type>>
+>
+>,
+allocator<account_authority_object>
+>
+account_authority_index;
+
+
+struct by_account_bandwidth_type;
+
+typedef multi_index_container<
+        account_bandwidth_object,
+        indexed_by<
+                ordered_unique<tag<by_id>,
+                        member<account_bandwidth_object, account_bandwidth_id_type, &account_bandwidth_object::id>>,
+                ordered_unique<tag<by_account_bandwidth_type>,
+                        composite_key < account_bandwidth_object,
+                        member<account_bandwidth_object, account_name_type, &account_bandwidth_object::account>,
+                        member<account_bandwidth_object, bandwidth_type, &account_bandwidth_object::type>
                 >
+        >
+>,
+allocator<account_bandwidth_object>
+>
+account_bandwidth_index;
+
+struct by_delegation;
+struct by_received;
+
+using vesting_delegation_index = multi_index_container<
+    vesting_delegation_object,
+    indexed_by<
+        ordered_unique<
+            tag<by_id>,
+            member<vesting_delegation_object, vesting_delegation_id_type, &vesting_delegation_object::id>>,
+        ordered_unique<
+            tag<by_delegation>,
+            composite_key<
+                vesting_delegation_object,
+                member<vesting_delegation_object, account_name_type, &vesting_delegation_object::delegator>,
+                member<vesting_delegation_object, account_name_type, &vesting_delegation_object::delegatee>
             >,
-            allocator<vesting_delegation_object>
-        >;
+            composite_key_compare<protocol::string_less, protocol::string_less>
+        >,
+        ordered_unique<
+            tag<by_received>,
+            composite_key<
+                vesting_delegation_object,
+                member<vesting_delegation_object, account_name_type, &vesting_delegation_object::delegatee>,
+                member<vesting_delegation_object, account_name_type, &vesting_delegation_object::delegator>
+            >,
+            composite_key_compare<protocol::string_less, protocol::string_less>
+        >
+    >,
+    allocator<vesting_delegation_object>
+>;
 
-        struct by_expiration;
-        struct by_account_expiration;
+struct by_expiration;
+struct by_account_expiration;
 
-        using vesting_delegation_expiration_index = multi_index_container<
-            vesting_delegation_expiration_object,
-            indexed_by<
-                ordered_unique<
-                    tag<by_id>,
-                    member<vesting_delegation_expiration_object, vesting_delegation_expiration_id_type, &vesting_delegation_expiration_object::id>>,
-                ordered_unique<
-                    tag<by_expiration>,
-                    composite_key<
-                        vesting_delegation_expiration_object,
-                        member<vesting_delegation_expiration_object, time_point_sec, &vesting_delegation_expiration_object::expiration>,
-                        member<vesting_delegation_expiration_object, vesting_delegation_expiration_id_type, &vesting_delegation_expiration_object::id>
-                    >,
-                    composite_key_compare<std::less<time_point_sec>, std::less<vesting_delegation_expiration_id_type>>
+using vesting_delegation_expiration_index = multi_index_container<
+    vesting_delegation_expiration_object,
+    indexed_by<
+        ordered_unique<
+            tag<by_id>,
+            member<vesting_delegation_expiration_object, vesting_delegation_expiration_id_type, &vesting_delegation_expiration_object::id>>,
+        ordered_unique<
+            tag<by_expiration>,
+            composite_key<
+                vesting_delegation_expiration_object,
+                member<vesting_delegation_expiration_object, time_point_sec, &vesting_delegation_expiration_object::expiration>,
+                member<vesting_delegation_expiration_object, vesting_delegation_expiration_id_type, &vesting_delegation_expiration_object::id>
+            >,
+            composite_key_compare<std::less<time_point_sec>, std::less<vesting_delegation_expiration_id_type>>
+        >,
+        ordered_unique<
+            tag<by_account_expiration>,
+            composite_key<
+                vesting_delegation_expiration_object,
+                member<vesting_delegation_expiration_object, account_name_type, &vesting_delegation_expiration_object::delegator>,
+                member<vesting_delegation_expiration_object, time_point_sec, &vesting_delegation_expiration_object::expiration>,
+                member<vesting_delegation_expiration_object, vesting_delegation_expiration_id_type, &vesting_delegation_expiration_object::id>
+            >,
+            composite_key_compare<std::less<account_name_type>, std::less<time_point_sec>, std::less<vesting_delegation_expiration_id_type>>
+        >
+    >,
+    allocator<vesting_delegation_expiration_object>
+>;
+
+struct by_expiration;
+
+typedef multi_index_container<
+        account_recovery_request_object,
+        indexed_by<
+                ordered_unique<tag<by_id>,
+                        member<account_recovery_request_object, account_recovery_request_id_type, &account_recovery_request_object::id>>,
+                ordered_unique<tag<by_account>,
+                        composite_key < account_recovery_request_object,
+                        member<account_recovery_request_object, account_name_type, &account_recovery_request_object::account_to_recover>,
+                        member<account_recovery_request_object, account_recovery_request_id_type, &account_recovery_request_object::id>
                 >,
-                ordered_unique<
-                    tag<by_account_expiration>,
-                    composite_key<
-                        vesting_delegation_expiration_object,
-                        member<vesting_delegation_expiration_object, account_name_type, &vesting_delegation_expiration_object::delegator>,
-                        member<vesting_delegation_expiration_object, time_point_sec, &vesting_delegation_expiration_object::expiration>,
-                        member<vesting_delegation_expiration_object, vesting_delegation_expiration_id_type, &vesting_delegation_expiration_object::id>
-                    >,
-                    composite_key_compare<std::less<account_name_type>, std::less<time_point_sec>, std::less<vesting_delegation_expiration_id_type>>
-                >
-            >,
-            allocator<vesting_delegation_expiration_object>
-        >;
+                composite_key_compare <
+                std::less<account_name_type>, std::less<account_recovery_request_id_type>>
+>,
+ordered_unique<tag<by_expiration>,
+        composite_key < account_recovery_request_object,
+        member<account_recovery_request_object, time_point_sec, &account_recovery_request_object::expires>,
+        member<account_recovery_request_object, account_recovery_request_id_type, &account_recovery_request_object::id>
+>,
+composite_key_compare <std::less<time_point_sec>, std::less<account_recovery_request_id_type>>
+>
+>,
+allocator<account_recovery_request_object>
+>
+account_recovery_request_index;
 
-        struct by_expiration;
+struct by_effective_date;
 
-        typedef multi_index_container<
-                account_recovery_request_object,
-                indexed_by<
-                        ordered_unique<tag<by_id>,
-                                member<account_recovery_request_object, account_recovery_request_id_type, &account_recovery_request_object::id>>,
-                        ordered_unique<tag<by_account>,
-                                composite_key < account_recovery_request_object,
-                                member<account_recovery_request_object, account_name_type, &account_recovery_request_object::account_to_recover>,
-                                member<account_recovery_request_object, account_recovery_request_id_type, &account_recovery_request_object::id>
-                        >,
-                        composite_key_compare <
-                        std::less<account_name_type>, std::less<account_recovery_request_id_type>>
-        >,
-        ordered_unique<tag<by_expiration>,
-                composite_key < account_recovery_request_object,
-                member<account_recovery_request_object, time_point_sec, &account_recovery_request_object::expires>,
-                member<account_recovery_request_object, account_recovery_request_id_type, &account_recovery_request_object::id>
-        >,
-        composite_key_compare <std::less<time_point_sec>, std::less<account_recovery_request_id_type>>
-        >
-        >,
-        allocator<account_recovery_request_object>
-        >
-        account_recovery_request_index;
-
-        struct by_effective_date;
-
-        typedef multi_index_container<
-                change_recovery_account_request_object,
-                indexed_by<
-                        ordered_unique<tag<by_id>,
-                                member<change_recovery_account_request_object, change_recovery_account_request_id_type, &change_recovery_account_request_object::id>>,
-                        ordered_unique<tag<by_account>,
-                                composite_key <
-                                change_recovery_account_request_object,
-                                member<change_recovery_account_request_object, account_name_type, &change_recovery_account_request_object::account_to_recover>,
-                                member<change_recovery_account_request_object, change_recovery_account_request_id_type, &change_recovery_account_request_object::id>
-                        >,
-                        composite_key_compare <
-                        std::less<account_name_type>, std::less<change_recovery_account_request_id_type>>
-        >,
-        ordered_unique<tag<by_effective_date>,
-                composite_key < change_recovery_account_request_object,
-                member<change_recovery_account_request_object, time_point_sec, &change_recovery_account_request_object::effective_on>,
-                member<change_recovery_account_request_object, change_recovery_account_request_id_type, &change_recovery_account_request_object::id>
-        >,
-        composite_key_compare <std::less<time_point_sec>, std::less<change_recovery_account_request_id_type>>
-        >
-        >,
-        allocator<change_recovery_account_request_object>
-        >
-        change_recovery_account_request_index;
+typedef multi_index_container<
+        change_recovery_account_request_object,
+        indexed_by<
+                ordered_unique<tag<by_id>,
+                        member<change_recovery_account_request_object, change_recovery_account_request_id_type, &change_recovery_account_request_object::id>>,
+                ordered_unique<tag<by_account>,
+                        composite_key <
+                        change_recovery_account_request_object,
+                        member<change_recovery_account_request_object, account_name_type, &change_recovery_account_request_object::account_to_recover>,
+                        member<change_recovery_account_request_object, change_recovery_account_request_id_type, &change_recovery_account_request_object::id>
+                >,
+                composite_key_compare <
+                std::less<account_name_type>, std::less<change_recovery_account_request_id_type>>
+>,
+ordered_unique<tag<by_effective_date>,
+        composite_key < change_recovery_account_request_object,
+        member<change_recovery_account_request_object, time_point_sec, &change_recovery_account_request_object::effective_on>,
+        member<change_recovery_account_request_object, change_recovery_account_request_id_type, &change_recovery_account_request_object::id>
+>,
+composite_key_compare <std::less<time_point_sec>, std::less<change_recovery_account_request_id_type>>
+>
+>,
+allocator<change_recovery_account_request_object>
+>
+change_recovery_account_request_index;
 
 } } // golos::chain
+
 
 FC_REFLECT((golos::chain::account_object),
         (id)(name)(memo_key)(proxy)(last_account_update)

--- a/plugins/database_api/api.cpp
+++ b/plugins/database_api/api.cpp
@@ -19,1036 +19,1036 @@
 #define CHECK_ARGS_COUNT(min, max) \
    FC_ASSERT(n_args >= min && n_args <= max, "Expected #min-#max arguments, got ${n}", ("n", n_args));
 
+
 namespace golos { namespace plugins { namespace database_api {
 
-            struct block_applied_callback_info {
+struct block_applied_callback_info {
+    using ptr = std::shared_ptr<block_applied_callback_info>;
+    using cont = std::list<ptr>;
 
-                using ptr = std::shared_ptr<block_applied_callback_info>;
-                using cont = std::list<ptr>;
+    block_applied_callback callback;
+    boost::signals2::connection connection;
+    cont::iterator it;
 
-                block_applied_callback callback;
-                boost::signals2::connection connection;
-                cont::iterator it;
+    void connect(
+        boost::signals2::signal<void(const signed_block &)> &sig,
+        cont &free_cont,
+        block_applied_callback cb
+    ) {
+        callback = cb;
 
-                void connect(
-                    boost::signals2::signal<void(const signed_block &)> &sig,
-                    cont &free_cont,
-                    block_applied_callback cb
-                ) {
-                    callback = cb;
+        connection = sig.connect([this, &free_cont](const signed_block &block) {
+            try {
+                this->callback(fc::variant(block));
+            } catch (...) {
+                free_cont.push_back(*this->it);
+                this->connection.disconnect();
+            }
+        });
+    }
+};
 
-                    connection = sig.connect([this, &free_cont](const signed_block &block) {
-                        try {
-                            this->callback(fc::variant(block));
-                        } catch (...) {
-                            free_cont.push_back(*this->it);
-                            this->connection.disconnect();
+
+struct plugin::api_impl final {
+public:
+    api_impl();
+    ~api_impl();
+
+    void startup() {
+    }
+
+    // Subscriptions
+    void set_subscribe_callback(std::function<void(const variant &)> cb, bool clear_filter);
+    void set_pending_transaction_callback(std::function<void(const variant &)> cb);
+    void set_block_applied_callback(block_applied_callback cb);
+    void clear_block_applied_callback();
+    void cancel_all_subscriptions();
+
+    // Blocks and transactions
+    optional<block_header> get_block_header(uint32_t block_num) const;
+    optional<signed_block> get_block(uint32_t block_num) const;
+
+    // Globals
+    fc::variant_object get_config() const;
+    dynamic_global_property_api_object get_dynamic_global_properties() const;
+
+    // Accounts
+    std::vector<account_api_object> get_accounts(std::vector<std::string> names) const;
+    std::vector<optional<account_api_object>> lookup_account_names(const std::vector<std::string> &account_names) const;
+    std::set<std::string> lookup_accounts(const std::string &lower_bound_name, uint32_t limit) const;
+    uint64_t get_account_count() const;
+
+    // Witnesses
+    std::vector<optional<witness_api_object>> get_witnesses(const std::vector<witness_object::id_type> &witness_ids) const;
+    fc::optional<witness_api_object> get_witness_by_account(std::string account_name) const;
+    std::set<account_name_type> lookup_witness_accounts(const std::string &lower_bound_name, uint32_t limit) const;
+    uint64_t get_witness_count() const;
+
+    // Authority / validation
+    std::string get_transaction_hex(const signed_transaction &trx) const;
+    std::set<public_key_type> get_required_signatures(const signed_transaction &trx, const flat_set<public_key_type> &available_keys) const;
+    std::set<public_key_type> get_potential_signatures(const signed_transaction &trx) const;
+    bool verify_authority(const signed_transaction &trx) const;
+    bool verify_account_authority(const std::string &name_or_id, const flat_set<public_key_type> &signers) const;
+
+    std::vector<withdraw_route> get_withdraw_routes(std::string account, withdraw_route_type type) const;
+    std::vector<witness_api_object> get_witnesses_by_vote(std::string from, uint32_t limit) const;
+    std::vector<account_name_type> get_miner_queue() const;
+    std::vector<proposal_api_object> get_proposed_transactions(const std::string&, uint32_t, uint32_t) const;
+
+    template<typename T>
+    void subscribe_to_item(const T &i) const {
+        auto vec = fc::raw::pack(i);
+        if (!_subscribe_callback) {
+            return;
+        }
+
+        if (!is_subscribed_to_item(i)) {
+            idump((i));
+            _subscribe_filter.insert(vec.data(), vec.size());
+        }
+    }
+
+    template<typename T>
+    bool is_subscribed_to_item(const T &i) const {
+        if (!_subscribe_callback) {
+            return false;
+        }
+
+        return _subscribe_filter.contains(i);
+    }
+
+    mutable fc::bloom_filter _subscribe_filter;
+    std::function<void(const fc::variant &)> _subscribe_callback;
+    std::function<void(const fc::variant &)> _pending_trx_callback;
+
+
+    golos::chain::database &database() const {
+        return _db;
+    }
+
+
+    std::map<std::pair<asset_symbol_type, asset_symbol_type>, std::function<void(const variant &)>> _market_subscriptions;
+
+    block_applied_callback_info::cont active_block_applied_callback;
+    block_applied_callback_info::cont free_block_applied_callback;
+
+private:
+
+    golos::chain::database &_db;
+};
+
+
+//void find_accounts(std::set<std::string> &accounts, const discussion &d) {
+//    accounts.insert(d.author);
+//}
+
+//////////////////////////////////////////////////////////////////////
+//                                                                  //
+// Subscriptions                                                    //
+//                                                                  //
+//////////////////////////////////////////////////////////////////////
+
+void plugin::set_subscribe_callback(std::function<void(const variant &)> cb, bool clear_filter) {
+    my->database().with_weak_read_lock([&]() {
+        my->set_subscribe_callback(cb, clear_filter);
+    });
+}
+
+void plugin::api_impl::set_subscribe_callback(
+    std::function<void(const variant &)> cb,
+    bool clear_filter
+) {
+    _subscribe_callback = cb;
+    if (clear_filter || !cb) {
+        static fc::bloom_parameters param;
+        param.projected_element_count = 10000;
+        param.false_positive_probability = 1.0 / 10000;
+        param.maximum_size = 1024 * 8 * 8 * 2;
+        param.compute_optimal_parameters();
+        _subscribe_filter = fc::bloom_filter(param);
+    }
+}
+
+void plugin::set_pending_transaction_callback(std::function<void(const variant &)> cb) {
+    my->database().with_weak_read_lock([&]() {
+        my->set_pending_transaction_callback(cb);
+    });
+}
+
+void plugin::api_impl::set_pending_transaction_callback(std::function<void(const variant &)> cb) {
+    _pending_trx_callback = cb;
+}
+
+void plugin::cancel_all_subscriptions() {
+    my->database().with_weak_read_lock([&]() {
+        my->cancel_all_subscriptions();
+    });
+}
+
+void plugin::api_impl::cancel_all_subscriptions() {
+    set_subscribe_callback(std::function<void(const fc::variant &)>(), true);
+}
+
+//////////////////////////////////////////////////////////////////////
+//                                                                  //
+// Constructors                                                     //
+//                                                                  //
+//////////////////////////////////////////////////////////////////////
+
+plugin::plugin()  {
+}
+
+plugin::~plugin() {
+}
+
+plugin::api_impl::api_impl() : _db(appbase::app().get_plugin<chain::plugin>().db())
+{
+    wlog("creating database plugin ${x}", ("x", int64_t(this)));
+}
+
+plugin::api_impl::~api_impl() {
+    elog("freeing database plugin ${x}", ("x", int64_t(this)));
+}
+
+//////////////////////////////////////////////////////////////////////
+//                                                                  //
+// Blocks and transactions                                          //
+//                                                                  //
+//////////////////////////////////////////////////////////////////////
+
+DEFINE_API(plugin, get_block_header) {
+    CHECK_ARG_SIZE(1)
+    return my->database().with_weak_read_lock([&]() {
+        return my->get_block_header(args.args->at(0).as<uint32_t>());
+    });
+}
+
+optional<block_header> plugin::api_impl::get_block_header(uint32_t block_num) const {
+    auto result = database().fetch_block_by_number(block_num);
+    if (result) {
+        return *result;
+    }
+    return {};
+}
+
+DEFINE_API(plugin, get_block) {
+    CHECK_ARG_SIZE(1)
+    return my->database().with_weak_read_lock([&]() {
+        return my->get_block(args.args->at(0).as<uint32_t>());
+    });
+}
+
+optional<signed_block> plugin::api_impl::get_block(uint32_t block_num) const {
+    return database().fetch_block_by_number(block_num);
+}
+
+DEFINE_API(plugin, set_block_applied_callback) {
+    CHECK_ARG_SIZE(1)
+
+    // Delegate connection handlers to callback
+    msg_pack_transfer transfer(args);
+
+    my->database().with_weak_read_lock([&]{
+        my->set_block_applied_callback([msg = transfer.msg()](const fc::variant & block_header) {
+            msg->unsafe_result(fc::variant(block_header));
+        });
+    });
+
+    transfer.complete();
+
+    return {};
+}
+
+void plugin::api_impl::set_block_applied_callback(std::function<void(const variant &block_header)> callback) {
+    auto info_ptr = std::make_shared<block_applied_callback_info>();
+
+    active_block_applied_callback.push_back(info_ptr);
+    info_ptr->it = std::prev(active_block_applied_callback.end());
+
+    info_ptr->connect(database().applied_block, free_block_applied_callback, callback);
+}
+
+void plugin::api_impl::clear_block_applied_callback() {
+    for (auto &info: free_block_applied_callback) {
+        active_block_applied_callback.erase(info->it);
+    }
+    free_block_applied_callback.clear();
+}
+
+void plugin::clear_block_applied_callback() {
+    my->clear_block_applied_callback();
+}
+
+//////////////////////////////////////////////////////////////////////
+//                                                                  //
+// Globals                                                          //
+//                                                                  //
+//////////////////////////////////////////////////////////////////////
+
+DEFINE_API(plugin, get_config) {
+    return my->database().with_weak_read_lock([&]() {
+        return my->get_config();
+    });
+}
+
+fc::variant_object plugin::api_impl::get_config() const {
+    return golos::protocol::get_config();
+}
+
+DEFINE_API(plugin, get_dynamic_global_properties) {
+    return my->database().with_weak_read_lock([&]() {
+        return my->get_dynamic_global_properties();
+    });
+}
+
+DEFINE_API(plugin, get_chain_properties) {
+    return my->database().with_weak_read_lock([&]() {
+        return my->database().get_witness_schedule_object().median_props;
+    });
+}
+
+DEFINE_API(plugin, get_feed_history) {
+    return my->database().with_weak_read_lock([&]() {
+        return feed_history_api_object(my->database().get_feed_history());
+    });
+}
+
+DEFINE_API(plugin, get_current_median_history_price) {
+    return my->database().with_weak_read_lock([&]() {
+        return my->database().get_feed_history().current_median_history;
+    });
+}
+
+dynamic_global_property_api_object plugin::api_impl::get_dynamic_global_properties() const {
+    return database().get(dynamic_global_property_object::id_type());
+}
+
+DEFINE_API(plugin, get_witness_schedule) {
+    return my->database().with_weak_read_lock([&]() {
+        return my->database().get(witness_schedule_object::id_type());
+    });
+}
+
+DEFINE_API(plugin, get_hardfork_version) {
+    return my->database().with_weak_read_lock([&]() {
+        return my->database().get(hardfork_property_object::id_type()).current_hardfork_version;
+    });
+}
+
+DEFINE_API(plugin, get_next_scheduled_hardfork) {
+    return my->database().with_weak_read_lock([&]() {
+        scheduled_hardfork shf;
+        const auto &hpo = my->database().get(hardfork_property_object::id_type());
+        shf.hf_version = hpo.next_hardfork;
+        shf.live_time = hpo.next_hardfork_time;
+        return shf;
+    });
+}
+
+//////////////////////////////////////////////////////////////////////
+//                                                                  //
+// Accounts                                                         //
+//                                                                  //
+//////////////////////////////////////////////////////////////////////
+
+DEFINE_API(plugin, get_accounts) {
+    CHECK_ARG_SIZE(1)
+    return my->database().with_weak_read_lock([&]() {
+        return my->get_accounts(args.args->at(0).as<vector<std::string> >());
+    });
+}
+
+std::vector<account_api_object> plugin::api_impl::get_accounts(std::vector<std::string> names) const {
+    const auto &idx = _db.get_index<account_index>().indices().get<by_name>();
+    const auto &vidx = _db.get_index<witness_vote_index>().indices().get<by_account_witness>();
+    std::vector<account_api_object> results;
+
+    for (auto name: names) {
+        auto itr = idx.find(name);
+        if (itr != idx.end()) {
+            results.push_back(account_api_object(*itr, _db));
+            auto vitr = vidx.lower_bound(boost::make_tuple(itr->id, witness_id_type()));
+            while (vitr != vidx.end() && vitr->account == itr->id) {
+                results.back().witness_votes.insert(_db.get(vitr->witness).owner);
+                ++vitr;
+            }
+        }
+        else {
+            wlog("database_api: No such account with name \"${name}\" in account index", ("name", name) );
+        }
+    }
+
+    return results;
+}
+
+DEFINE_API(plugin, lookup_account_names) {
+    CHECK_ARG_SIZE(1)
+    return my->database().with_weak_read_lock([&]() {
+        return my->lookup_account_names(args.args->at(0).as<vector<std::string> >());
+    });
+}
+
+std::vector<optional<account_api_object>> plugin::api_impl::lookup_account_names(
+    const std::vector<std::string> &account_names
+) const {
+    std::vector<optional<account_api_object>> result;
+    result.reserve(account_names.size());
+
+    for (auto &name : account_names) {
+        auto itr = database().find<account_object, by_name>(name);
+
+        if (itr) {
+            result.push_back(account_api_object(*itr, database()));
+        } else {
+            result.push_back(optional<account_api_object>());
+        }
+    }
+
+    return result;
+}
+
+DEFINE_API(plugin, lookup_accounts) {
+    CHECK_ARG_SIZE(2)
+    account_name_type lower_bound_name = args.args->at(0).as<account_name_type>();
+    uint32_t limit = args.args->at(1).as<uint32_t>();
+    return my->database().with_weak_read_lock([&]() {
+        return my->lookup_accounts(lower_bound_name, limit);
+    });
+}
+
+std::set<std::string> plugin::api_impl::lookup_accounts(
+    const std::string &lower_bound_name,
+        uint32_t limit
+) const {
+    FC_ASSERT(limit <= 1000);
+    const auto &accounts_by_name = database().get_index<account_index>().indices().get<by_name>();
+    std::set<std::string> result;
+
+    for (auto itr = accounts_by_name.lower_bound(lower_bound_name);
+            limit-- && itr != accounts_by_name.end(); ++itr) {
+        result.insert(itr->name);
+    }
+
+    return result;
+}
+
+DEFINE_API(plugin, get_account_count) {
+    return my->database().with_weak_read_lock([&]() {
+        return my->get_account_count();
+    });
+}
+
+uint64_t plugin::api_impl::get_account_count() const {
+    return database().get_index<account_index>().indices().size();
+}
+
+DEFINE_API(plugin, get_owner_history) {
+    CHECK_ARG_SIZE(1)
+    auto account = args.args->at(0).as<string>();
+    return my->database().with_weak_read_lock([&]() {
+        std::vector<owner_authority_history_api_object> results;
+        const auto &hist_idx = my->database().get_index<owner_authority_history_index>().indices().get<
+                by_account>();
+        auto itr = hist_idx.lower_bound(account);
+
+        while (itr != hist_idx.end() && itr->account == account) {
+            results.push_back(owner_authority_history_api_object(*itr));
+            ++itr;
+        }
+
+        return results;
+    });
+}
+
+DEFINE_API(plugin, get_recovery_request) {
+    CHECK_ARG_SIZE(1)
+    auto account = args.args->at(0).as<account_name_type>();
+    return my->database().with_weak_read_lock([&]() {
+        optional<account_recovery_request_api_object> result;
+
+        const auto &rec_idx = my->database().get_index<account_recovery_request_index>().indices().get<
+                by_account>();
+        auto req = rec_idx.find(account);
+
+        if (req != rec_idx.end()) {
+            result = account_recovery_request_api_object(*req);
+        }
+
+        return result;
+    });
+}
+
+DEFINE_API(plugin, get_escrow) {
+    CHECK_ARG_SIZE(2)
+    auto from = args.args->at(0).as<account_name_type>();
+    auto escrow_id = args.args->at(1).as<uint32_t>();
+    return my->database().with_weak_read_lock([&]() {
+        optional<escrow_api_object> result;
+
+        try {
+            result = my->database().get_escrow(from, escrow_id);
+        } catch (...) {
+        }
+
+        return result;
+    });
+}
+
+std::vector<withdraw_route> plugin::api_impl::get_withdraw_routes(
+    std::string account,
+    withdraw_route_type type
+) const {
+    std::vector<withdraw_route> result;
+
+    const auto &acc = database().get_account(account);
+
+    if (type == outgoing || type == all) {
+        const auto &by_route = database().get_index<withdraw_vesting_route_index>().indices().get<
+                by_withdraw_route>();
+        auto route = by_route.lower_bound(acc.id);
+
+        while (route != by_route.end() && route->from_account == acc.id) {
+            withdraw_route r;
+            r.from_account = account;
+            r.to_account = database().get(route->to_account).name;
+            r.percent = route->percent;
+            r.auto_vest = route->auto_vest;
+
+            result.push_back(r);
+
+            ++route;
+        }
+    }
+
+    if (type == incoming || type == all) {
+        const auto &by_dest = database().get_index<withdraw_vesting_route_index>().indices().get<by_destination>();
+        auto route = by_dest.lower_bound(acc.id);
+
+        while (route != by_dest.end() && route->to_account == acc.id) {
+            withdraw_route r;
+            r.from_account = database().get(route->from_account).name;
+            r.to_account = account;
+            r.percent = route->percent;
+            r.auto_vest = route->auto_vest;
+
+            result.push_back(r);
+
+            ++route;
+        }
+    }
+
+    return result;
+}
+
+
+DEFINE_API(plugin, get_withdraw_routes) {
+    FC_ASSERT(args.args->size() == 1 || args.args->size() == 2, "Expected 1-2 arguments, was ${n}",
+                ("n", args.args->size()));
+    auto account = args.args->at(0).as<string>();
+    auto type = args.args->at(1).as<withdraw_route_type>();
+    return my->database().with_weak_read_lock([&]() {
+        return my->get_withdraw_routes(account, type);
+    });
+}
+
+DEFINE_API(plugin, get_account_bandwidth) {
+    CHECK_ARG_SIZE(2)
+    auto account = args.args->at(0).as<string>();
+    auto type = args.args->at(1).as<bandwidth_type>();
+    optional<account_bandwidth_api_object> result;
+    auto band = my->database().find<account_bandwidth_object, by_account_bandwidth_type>(
+            boost::make_tuple(account, type));
+    if (band != nullptr) {
+        result = *band;
+    }
+
+    return result;
+}
+
+//////////////////////////////////////////////////////////////////////
+//                                                                  //
+// Witnesses                                                        //
+//                                                                  //
+//////////////////////////////////////////////////////////////////////
+
+DEFINE_API(plugin, get_witnesses) {
+    CHECK_ARG_SIZE(1)
+    auto witness_ids = args.args->at(0).as<vector<witness_object::id_type> >();
+    return my->database().with_weak_read_lock([&]() {
+        return my->get_witnesses(witness_ids);
+    });
+}
+
+std::vector<optional<witness_api_object>> plugin::api_impl::get_witnesses(
+    const std::vector<witness_object::id_type> &witness_ids
+) const {
+    std::vector<optional<witness_api_object>> result;
+    result.reserve(witness_ids.size());
+    std::transform(witness_ids.begin(), witness_ids.end(), std::back_inserter(result),
+                    [this](witness_object::id_type id) -> optional<witness_api_object> {
+                        if (auto o = database().find(id)) {
+                            return *o;
                         }
+                        return {};
                     });
+    return result;
+}
+
+DEFINE_API(plugin, get_witness_by_account) {
+    CHECK_ARG_SIZE(1)
+    auto account_name = args.args->at(0).as<std::string>();
+    return my->database().with_weak_read_lock([&]() {
+        return my->get_witness_by_account(account_name);
+    });
+}
+
+
+fc::optional<witness_api_object> plugin::api_impl::get_witness_by_account(
+    std::string account_name
+) const {
+    const auto &idx = database().get_index<witness_index>().indices().get<by_name>();
+    auto itr = idx.find(account_name);
+    if (itr != idx.end()) {
+        return witness_api_object(*itr);
+    }
+    return {};
+}
+
+std::vector<witness_api_object> plugin::api_impl::get_witnesses_by_vote(
+    std::string from,
+    uint32_t limit
+) const {
+    //idump((from)(limit));
+    FC_ASSERT(limit <= 100);
+
+    std::vector<witness_api_object> result;
+    result.reserve(limit);
+
+    const auto &name_idx = database().get_index<witness_index>().indices().get<by_name>();
+    const auto &vote_idx = database().get_index<witness_index>().indices().get<by_vote_name>();
+
+    auto itr = vote_idx.begin();
+    if (from.size()) {
+        auto nameitr = name_idx.find(from);
+        FC_ASSERT(nameitr != name_idx.end(), "invalid witness name ${n}", ("n", from));
+        itr = vote_idx.iterator_to(*nameitr);
+    }
+
+    while (itr != vote_idx.end() && result.size() < limit && itr->votes > 0) {
+        result.push_back(witness_api_object(*itr));
+        ++itr;
+    }
+    return result;
+
+}
+
+DEFINE_API(plugin, get_witnesses_by_vote) {
+    CHECK_ARG_SIZE(2)
+    auto from = args.args->at(0).as<std::string>();
+    auto limit = args.args->at(1).as<uint32_t>();
+    return my->database().with_weak_read_lock([&]() {
+        return my->get_witnesses_by_vote(from, limit);
+    });
+}
+
+
+DEFINE_API(plugin, lookup_witness_accounts) {
+    CHECK_ARG_SIZE(2)
+    auto lower_bound_name = args.args->at(0).as<std::string>();
+    auto limit = args.args->at(1).as<uint32_t>();
+    return my->database().with_weak_read_lock([&]() {
+        return my->lookup_witness_accounts(lower_bound_name, limit);
+    });
+}
+
+std::set<account_name_type> plugin::api_impl::lookup_witness_accounts(
+    const std::string &lower_bound_name,
+    uint32_t limit
+) const {
+    FC_ASSERT(limit <= 1000);
+    const auto &witnesses_by_id = database().get_index<witness_index>().indices().get<by_id>();
+
+    // get all the names and look them all up, sort them, then figure out what
+    // records to return.  This could be optimized, but we expect the
+    // number of witnesses to be few and the frequency of calls to be rare
+    std::set<account_name_type> witnesses_by_account_name;
+    for (const witness_api_object &witness : witnesses_by_id) {
+        if (witness.owner >= lower_bound_name) { // we can ignore anything below lower_bound_name
+            witnesses_by_account_name.insert(witness.owner);
+        }
+    }
+
+    auto end_iter = witnesses_by_account_name.begin();
+    while (end_iter != witnesses_by_account_name.end() && limit--) {
+        ++end_iter;
+    }
+    witnesses_by_account_name.erase(end_iter, witnesses_by_account_name.end());
+    return witnesses_by_account_name;
+}
+
+DEFINE_API(plugin, get_witness_count) {
+    return my->database().with_weak_read_lock([&]() {
+        return my->get_witness_count();
+    });
+}
+
+uint64_t plugin::api_impl::get_witness_count() const {
+    return database().get_index<witness_index>().indices().size();
+}
+
+//////////////////////////////////////////////////////////////////////
+//                                                                  //
+// Authority / validation                                           //
+//                                                                  //
+//////////////////////////////////////////////////////////////////////
+
+DEFINE_API(plugin, get_transaction_hex) {
+    CHECK_ARG_SIZE(1)
+    auto trx = args.args->at(0).as<signed_transaction>();
+    return my->database().with_weak_read_lock([&]() {
+        return my->get_transaction_hex(trx);
+    });
+}
+
+std::string plugin::api_impl::get_transaction_hex(const signed_transaction &trx) const {
+    return fc::to_hex(fc::raw::pack(trx));
+}
+
+DEFINE_API(plugin, get_required_signatures) {
+    CHECK_ARG_SIZE(2)
+    auto trx = args.args->at(0).as<signed_transaction>();
+    auto available_keys = args.args->at(1).as<flat_set<public_key_type>>();
+    return my->database().with_weak_read_lock([&]() {
+        return my->get_required_signatures(trx, available_keys);
+    });
+}
+
+std::set<public_key_type> plugin::api_impl::get_required_signatures(
+    const signed_transaction &trx,
+    const flat_set<public_key_type> &available_keys
+) const {
+    //   wdump((trx)(available_keys));
+    auto result = trx.get_required_signatures(
+        STEEMIT_CHAIN_ID, available_keys,
+        [&](std::string account_name) {
+            return authority(database().get<account_authority_object, by_account>(account_name).active);
+        },
+        [&](std::string account_name) {
+            return authority(database().get<account_authority_object, by_account>(account_name).owner);
+        },
+        [&](std::string account_name) {
+            return authority(database().get<account_authority_object, by_account>(account_name).posting);
+        },
+        STEEMIT_MAX_SIG_CHECK_DEPTH
+    );
+    //   wdump((result));
+    return result;
+}
+
+DEFINE_API(plugin, get_potential_signatures) {
+    CHECK_ARG_SIZE(1)
+    return my->database().with_weak_read_lock([&]() {
+        return my->get_potential_signatures(args.args->at(0).as<signed_transaction>());
+    });
+}
+
+std::set<public_key_type> plugin::api_impl::get_potential_signatures(const signed_transaction &trx) const {
+    //   wdump((trx));
+    std::set<public_key_type> result;
+    trx.get_required_signatures(STEEMIT_CHAIN_ID, flat_set<public_key_type>(),
+        [&](account_name_type account_name) {
+            const auto &auth = database().get<account_authority_object, by_account>(account_name).active;
+            for (const auto &k : auth.get_keys()) {
+                result.insert(k);
+            }
+            return authority(auth);
+        },
+        [&](account_name_type account_name) {
+            const auto &auth = database().get<account_authority_object, by_account>(account_name).owner;
+            for (const auto &k : auth.get_keys()) {
+                result.insert(k);
+            }
+            return authority(auth);
+        },
+        [&](account_name_type account_name) {
+            const auto &auth = database().get<account_authority_object, by_account>(account_name).posting;
+            for (const auto &k : auth.get_keys()) {
+                result.insert(k);
+            }
+            return authority(auth);
+        },
+        STEEMIT_MAX_SIG_CHECK_DEPTH
+    );
+
+    //   wdump((result));
+    return result;
+}
+
+DEFINE_API(plugin, verify_authority) {
+    CHECK_ARG_SIZE(1)
+    return my->database().with_weak_read_lock([&]() {
+        return my->verify_authority(args.args->at(0).as<signed_transaction>());
+    });
+}
+
+bool plugin::api_impl::verify_authority(const signed_transaction &trx) const {
+    trx.verify_authority(STEEMIT_CHAIN_ID, [&](std::string account_name) {
+        return authority(database().get<account_authority_object, by_account>(account_name).active);
+    }, [&](std::string account_name) {
+        return authority(database().get<account_authority_object, by_account>(account_name).owner);
+    }, [&](std::string account_name) {
+        return authority(database().get<account_authority_object, by_account>(account_name).posting);
+    }, STEEMIT_MAX_SIG_CHECK_DEPTH);
+    return true;
+}
+
+DEFINE_API(plugin, verify_account_authority) {
+    CHECK_ARG_SIZE(2)
+    return my->database().with_weak_read_lock([&]() {
+        return my->verify_account_authority(args.args->at(0).as<account_name_type>(),
+                                            args.args->at(1).as<flat_set<public_key_type> >());
+    });
+}
+
+bool plugin::api_impl::verify_account_authority(
+    const std::string &name,
+    const flat_set<public_key_type> &keys
+) const {
+    FC_ASSERT(name.size() > 0);
+    auto account = database().find<account_object, by_name>(name);
+    FC_ASSERT(account, "no such account");
+
+    /// reuse trx.verify_authority by creating a dummy transfer
+    signed_transaction trx;
+    transfer_operation op;
+    op.from = account->name;
+    trx.operations.emplace_back(op);
+
+    return verify_authority(trx);
+}
+
+DEFINE_API(plugin, get_conversion_requests) {
+    CHECK_ARG_SIZE(1)
+    auto account = args.args->at(0).as<std::string>();
+    return my->database().with_weak_read_lock([&]() {
+        const auto &idx = my->database().get_index<convert_request_index>().indices().get<by_owner>();
+        std::vector<convert_request_api_object> result;
+        auto itr = idx.lower_bound(account);
+        while (itr != idx.end() && itr->owner == account) {
+            result.emplace_back(*itr);
+            ++itr;
+        }
+        return result;
+    });
+}
+
+
+std::vector<account_name_type> plugin::api_impl::get_miner_queue() const {
+    std::vector<account_name_type> result;
+    const auto &pow_idx = database().get_index<witness_index>().indices().get<by_pow>();
+
+    auto itr = pow_idx.upper_bound(0);
+    while (itr != pow_idx.end()) {
+        if (itr->pow_worker) {
+            result.push_back(itr->owner);
+        }
+        ++itr;
+    }
+    return result;
+}
+
+
+DEFINE_API(plugin, get_miner_queue) {
+    return my->database().with_weak_read_lock([&]() {
+        return my->get_miner_queue();
+    });
+}
+
+DEFINE_API(plugin, get_active_witnesses) {
+    return my->database().with_weak_read_lock([&]() {
+        const auto &wso = my->database().get_witness_schedule_object();
+        size_t n = wso.current_shuffled_witnesses.size();
+        vector<account_name_type> result;
+        result.reserve(n);
+        for (size_t i = 0; i < n; i++) {
+            if (wso.current_shuffled_witnesses[i] != "") {
+                result.push_back(wso.current_shuffled_witnesses[i]);
+            }
+        }
+        return result;
+    });
+}
+
+
+DEFINE_API(plugin, get_savings_withdraw_from) {
+    CHECK_ARG_SIZE(1)
+    auto account = args.args->at(0).as<string>();
+    return my->database().with_weak_read_lock([&]() {
+        std::vector<savings_withdraw_api_object> result;
+
+        const auto &from_rid_idx = my->database().get_index<savings_withdraw_index>().indices().get<by_from_rid>();
+        auto itr = from_rid_idx.lower_bound(account);
+        while (itr != from_rid_idx.end() && itr->from == account) {
+            result.push_back(savings_withdraw_api_object(*itr));
+            ++itr;
+        }
+        return result;
+    });
+}
+
+DEFINE_API(plugin, get_savings_withdraw_to) {
+    CHECK_ARG_SIZE(1)
+    auto account = args.args->at(0).as<string>();
+    return my->database().with_weak_read_lock([&]() {
+        std::vector<savings_withdraw_api_object> result;
+
+        const auto &to_complete_idx = my->database().get_index<savings_withdraw_index>().indices().get<by_to_complete>();
+        auto itr = to_complete_idx.lower_bound(account);
+        while (itr != to_complete_idx.end() && itr->to == account) {
+            result.push_back(savings_withdraw_api_object(*itr));
+            ++itr;
+        }
+        return result;
+    });
+}
+
+//vector<vesting_delegation_api_obj> get_vesting_delegations(string account, string from, uint32_t limit, delegations_type type = delegated) const;
+DEFINE_API(plugin, get_vesting_delegations) {
+    size_t n_args = args.args->size();
+    CHECK_ARGS_COUNT(2, 4);
+    auto account = args.args->at(0).as<string>();
+    auto from = args.args->at(1).as<string>();
+    auto limit = n_args >= 3 ? args.args->at(2).as<uint32_t>() : 100;
+    auto type = n_args >= 4 ? args.args->at(3).as<delegations_type>() : delegated;
+    bool sent = type == delegated;
+    FC_ASSERT(limit <= 1000);
+
+    vector<vesting_delegation_api_object> result;
+    result.reserve(limit);
+    return my->database().with_weak_read_lock([&]() {
+        auto fill_result = [&](const auto& idx) {
+            auto i = idx.lower_bound(std::make_tuple(account, from));
+            while (result.size() < limit && i != idx.end() && account == (sent ? i->delegator : i->delegatee)) {
+                result.push_back(*i++);
+            }
+        };
+        if (sent)
+            fill_result(my->database().get_index<vesting_delegation_index, by_delegation>());
+        else
+            fill_result(my->database().get_index<vesting_delegation_index, by_received>());
+        return result;
+    });
+}
+
+//vector<vesting_delegation_expiration_api_obj> get_expiring_vesting_delegations(string account, time_point_sec from, uint32_t limit = 100) const;
+DEFINE_API(plugin, get_expiring_vesting_delegations) {
+    size_t n_args = args.args->size();
+    CHECK_ARGS_COUNT(2, 3);
+    auto account = args.args->at(0).as<string>();
+    auto from = args.args->at(1).as<time_point_sec>();
+    uint32_t limit = n_args >= 3 ? args.args->at(2).as<uint32_t>() : 100;
+    FC_ASSERT(limit <= 1000);
+
+    return my->database().with_weak_read_lock([&]() {
+        vector<vesting_delegation_expiration_api_object> result;
+        result.reserve(limit);
+        const auto& idx = my->database().get_index<vesting_delegation_expiration_index, by_account_expiration>();
+        auto itr = idx.lower_bound(std::make_tuple(account, from));
+        while (result.size() < limit && itr != idx.end() && itr->delegator == account) {
+            result.push_back(*itr);
+            ++itr;
+        }
+        return result;
+    });
+}
+
+DEFINE_API(plugin, get_database_info) {
+    CHECK_ARG_SIZE(0);
+
+    // read lock doesn't seem needed...
+
+    database_info info;
+    auto& db = my->database();
+
+    info.free_size = db.free_memory();
+    info.total_size = db.max_memory();
+    info.reserved_size = db.reserved_memory();
+    info.used_size = info.total_size - info.free_size - info.reserved_size;
+
+    info.index_list.reserve(db.index_list_size());
+
+    for (auto it = db.index_list_begin(), et = db.index_list_end(); et != it; ++it) {
+        info.index_list.push_back({(*it)->name(), (*it)->size()});
+    }
+
+    return info;
+}
+
+std::vector<proposal_api_object> plugin::api_impl::get_proposed_transactions(
+    const std::string& a, uint32_t from, uint32_t limit
+) const {
+    std::vector<proposal_api_object> result;
+    std::set<proposal_object_id_type> id_set;
+    result.reserve(limit);
+
+    // list of published proposals
+    {
+        auto& idx = database().get_index<proposal_index>().indices().get<by_account>();
+        auto itr = idx.lower_bound(a);
+
+        for (; idx.end() != itr && itr->author == a && result.size() < limit; ++itr) {
+            id_set.insert(itr->id);
+            if (id_set.size() >= from) {
+                result.emplace_back(*itr);
+            }
+        }
+    }
+
+    // list of requested proposals
+    if (result.size() < limit) {
+        auto& idx = database().get_index<required_approval_index>().indices().get<by_account>();
+        auto& pidx = database().get_index<proposal_index>().indices().get<by_id>();
+        auto itr = idx.lower_bound(a);
+
+        for (; idx.end() != itr && itr->account == a && result.size() < limit; ++itr) {
+            if (!id_set.count(itr->proposal)) {
+                id_set.insert(itr->proposal);
+                auto pitr = pidx.find(itr->proposal);
+                if (pidx.end() != pitr && id_set.size() >= from) {
+                    result.emplace_back(*pitr);
                 }
-            };
-
-
-            struct plugin::api_impl final {
-            public:
-                api_impl();
-                ~api_impl();
-
-                void startup() {
-                }
-
-                // Subscriptions
-                void set_subscribe_callback(std::function<void(const variant &)> cb, bool clear_filter);
-                void set_pending_transaction_callback(std::function<void(const variant &)> cb);
-                void set_block_applied_callback(block_applied_callback cb);
-                void clear_block_applied_callback();
-                void cancel_all_subscriptions();
-
-                // Blocks and transactions
-                optional<block_header> get_block_header(uint32_t block_num) const;
-                optional<signed_block> get_block(uint32_t block_num) const;
-
-                // Globals
-                fc::variant_object get_config() const;
-                dynamic_global_property_api_object get_dynamic_global_properties() const;
-
-                // Accounts
-                std::vector<account_api_object> get_accounts(std::vector<std::string> names) const;
-                std::vector<optional<account_api_object>> lookup_account_names(const std::vector<std::string> &account_names) const;
-                std::set<std::string> lookup_accounts(const std::string &lower_bound_name, uint32_t limit) const;
-                uint64_t get_account_count() const;
-
-                // Witnesses
-                std::vector<optional<witness_api_object>> get_witnesses(const std::vector<witness_object::id_type> &witness_ids) const;
-                fc::optional<witness_api_object> get_witness_by_account(std::string account_name) const;
-                std::set<account_name_type> lookup_witness_accounts(const std::string &lower_bound_name, uint32_t limit) const;
-                uint64_t get_witness_count() const;
-
-                // Authority / validation
-                std::string get_transaction_hex(const signed_transaction &trx) const;
-                std::set<public_key_type> get_required_signatures(const signed_transaction &trx, const flat_set<public_key_type> &available_keys) const;
-                std::set<public_key_type> get_potential_signatures(const signed_transaction &trx) const;
-                bool verify_authority(const signed_transaction &trx) const;
-                bool verify_account_authority(const std::string &name_or_id, const flat_set<public_key_type> &signers) const;
-
-                std::vector<withdraw_route> get_withdraw_routes(std::string account, withdraw_route_type type) const;
-                std::vector<witness_api_object> get_witnesses_by_vote(std::string from, uint32_t limit) const;
-                std::vector<account_name_type> get_miner_queue() const;
-                std::vector<proposal_api_object> get_proposed_transactions(const std::string&, uint32_t, uint32_t) const;
-
-                template<typename T>
-                void subscribe_to_item(const T &i) const {
-                    auto vec = fc::raw::pack(i);
-                    if (!_subscribe_callback) {
-                        return;
-                    }
-
-                    if (!is_subscribed_to_item(i)) {
-                        idump((i));
-                        _subscribe_filter.insert(vec.data(), vec.size());
-                    }
-                }
-
-                template<typename T>
-                bool is_subscribed_to_item(const T &i) const {
-                    if (!_subscribe_callback) {
-                        return false;
-                    }
-
-                    return _subscribe_filter.contains(i);
-                }
-
-                mutable fc::bloom_filter _subscribe_filter;
-                std::function<void(const fc::variant &)> _subscribe_callback;
-                std::function<void(const fc::variant &)> _pending_trx_callback;
-
-
-                golos::chain::database &database() const {
-                    return _db;
-                }
-
-
-                std::map<std::pair<asset_symbol_type, asset_symbol_type>, std::function<void(const variant &)>> _market_subscriptions;
-
-                block_applied_callback_info::cont active_block_applied_callback;
-                block_applied_callback_info::cont free_block_applied_callback;
-
-            private:
-
-                golos::chain::database &_db;
-            };
-
-
-            //void find_accounts(std::set<std::string> &accounts, const discussion &d) {
-            //    accounts.insert(d.author);
-            //}
-
-            //////////////////////////////////////////////////////////////////////
-            //                                                                  //
-            // Subscriptions                                                    //
-            //                                                                  //
-            //////////////////////////////////////////////////////////////////////
-
-            void plugin::set_subscribe_callback(std::function<void(const variant &)> cb, bool clear_filter) {
-                my->database().with_weak_read_lock([&]() {
-                    my->set_subscribe_callback(cb, clear_filter);
-                });
-            }
-
-            void plugin::api_impl::set_subscribe_callback(
-                std::function<void(const variant &)> cb,
-                bool clear_filter
-            ) {
-                _subscribe_callback = cb;
-                if (clear_filter || !cb) {
-                    static fc::bloom_parameters param;
-                    param.projected_element_count = 10000;
-                    param.false_positive_probability = 1.0 / 10000;
-                    param.maximum_size = 1024 * 8 * 8 * 2;
-                    param.compute_optimal_parameters();
-                    _subscribe_filter = fc::bloom_filter(param);
-                }
-            }
-
-            void plugin::set_pending_transaction_callback(std::function<void(const variant &)> cb) {
-                my->database().with_weak_read_lock([&]() {
-                    my->set_pending_transaction_callback(cb);
-                });
-            }
-
-            void plugin::api_impl::set_pending_transaction_callback(std::function<void(const variant &)> cb) {
-                _pending_trx_callback = cb;
-            }
-
-            void plugin::cancel_all_subscriptions() {
-                my->database().with_weak_read_lock([&]() {
-                    my->cancel_all_subscriptions();
-                });
-            }
-
-            void plugin::api_impl::cancel_all_subscriptions() {
-                set_subscribe_callback(std::function<void(const fc::variant &)>(), true);
-            }
-
-            //////////////////////////////////////////////////////////////////////
-            //                                                                  //
-            // Constructors                                                     //
-            //                                                                  //
-            //////////////////////////////////////////////////////////////////////
-
-            plugin::plugin()  {
-            }
-
-            plugin::~plugin() {
-            }
-
-            plugin::api_impl::api_impl() : _db(appbase::app().get_plugin<chain::plugin>().db())
-            {
-                wlog("creating database plugin ${x}", ("x", int64_t(this)));
-            }
-
-            plugin::api_impl::~api_impl() {
-                elog("freeing database plugin ${x}", ("x", int64_t(this)));
-            }
-
-            //////////////////////////////////////////////////////////////////////
-            //                                                                  //
-            // Blocks and transactions                                          //
-            //                                                                  //
-            //////////////////////////////////////////////////////////////////////
-
-            DEFINE_API(plugin, get_block_header) {
-                CHECK_ARG_SIZE(1)
-                return my->database().with_weak_read_lock([&]() {
-                    return my->get_block_header(args.args->at(0).as<uint32_t>());
-                });
-            }
-
-            optional<block_header> plugin::api_impl::get_block_header(uint32_t block_num) const {
-                auto result = database().fetch_block_by_number(block_num);
-                if (result) {
-                    return *result;
-                }
-                return {};
-            }
-
-            DEFINE_API(plugin, get_block) {
-                CHECK_ARG_SIZE(1)
-                return my->database().with_weak_read_lock([&]() {
-                    return my->get_block(args.args->at(0).as<uint32_t>());
-                });
-            }
-
-            optional<signed_block> plugin::api_impl::get_block(uint32_t block_num) const {
-                return database().fetch_block_by_number(block_num);
-            }
-
-            DEFINE_API(plugin, set_block_applied_callback) {
-                CHECK_ARG_SIZE(1)
-
-                // Delegate connection handlers to callback
-                msg_pack_transfer transfer(args);
-
-                my->database().with_weak_read_lock([&]{
-                    my->set_block_applied_callback([msg = transfer.msg()](const fc::variant & block_header) {
-                        msg->unsafe_result(fc::variant(block_header));
-                    });
-                });
-
-                transfer.complete();
-
-                return {};
-            }
-
-            void plugin::api_impl::set_block_applied_callback(std::function<void(const variant &block_header)> callback) {
-                auto info_ptr = std::make_shared<block_applied_callback_info>();
-
-                active_block_applied_callback.push_back(info_ptr);
-                info_ptr->it = std::prev(active_block_applied_callback.end());
-
-                info_ptr->connect(database().applied_block, free_block_applied_callback, callback);
-            }
-
-            void plugin::api_impl::clear_block_applied_callback() {
-                for (auto &info: free_block_applied_callback) {
-                    active_block_applied_callback.erase(info->it);
-                }
-                free_block_applied_callback.clear();
-            }
-
-            void plugin::clear_block_applied_callback() {
-                my->clear_block_applied_callback();
-            }
-
-            //////////////////////////////////////////////////////////////////////
-            //                                                                  //
-            // Globals                                                          //
-            //                                                                  //
-            //////////////////////////////////////////////////////////////////////
-
-            DEFINE_API(plugin, get_config) {
-                return my->database().with_weak_read_lock([&]() {
-                    return my->get_config();
-                });
-            }
-
-            fc::variant_object plugin::api_impl::get_config() const {
-                return golos::protocol::get_config();
-            }
-
-            DEFINE_API(plugin, get_dynamic_global_properties) {
-                return my->database().with_weak_read_lock([&]() {
-                    return my->get_dynamic_global_properties();
-                });
-            }
-
-            DEFINE_API(plugin, get_chain_properties) {
-                return my->database().with_weak_read_lock([&]() {
-                    return my->database().get_witness_schedule_object().median_props;
-                });
-            }
-
-            DEFINE_API(plugin, get_feed_history) {
-                return my->database().with_weak_read_lock([&]() {
-                    return feed_history_api_object(my->database().get_feed_history());
-                });
-            }
-
-            DEFINE_API(plugin, get_current_median_history_price) {
-                return my->database().with_weak_read_lock([&]() {
-                    return my->database().get_feed_history().current_median_history;
-                });
-            }
-
-            dynamic_global_property_api_object plugin::api_impl::get_dynamic_global_properties() const {
-                return database().get(dynamic_global_property_object::id_type());
-            }
-
-            DEFINE_API(plugin, get_witness_schedule) {
-                return my->database().with_weak_read_lock([&]() {
-                    return my->database().get(witness_schedule_object::id_type());
-                });
-            }
-
-            DEFINE_API(plugin, get_hardfork_version) {
-                return my->database().with_weak_read_lock([&]() {
-                    return my->database().get(hardfork_property_object::id_type()).current_hardfork_version;
-                });
-            }
-
-            DEFINE_API(plugin, get_next_scheduled_hardfork) {
-                return my->database().with_weak_read_lock([&]() {
-                    scheduled_hardfork shf;
-                    const auto &hpo = my->database().get(hardfork_property_object::id_type());
-                    shf.hf_version = hpo.next_hardfork;
-                    shf.live_time = hpo.next_hardfork_time;
-                    return shf;
-                });
-            }
-
-            //////////////////////////////////////////////////////////////////////
-            //                                                                  //
-            // Accounts                                                         //
-            //                                                                  //
-            //////////////////////////////////////////////////////////////////////
-
-            DEFINE_API(plugin, get_accounts) {
-                CHECK_ARG_SIZE(1)
-                return my->database().with_weak_read_lock([&]() {
-                    return my->get_accounts(args.args->at(0).as<vector<std::string> >());
-                });
-            }
-
-            std::vector<account_api_object> plugin::api_impl::get_accounts(std::vector<std::string> names) const {
-                const auto &idx = _db.get_index<account_index>().indices().get<by_name>();
-                const auto &vidx = _db.get_index<witness_vote_index>().indices().get<by_account_witness>();
-                std::vector<account_api_object> results;
-
-                for (auto name: names) {
-                    auto itr = idx.find(name);
-                    if (itr != idx.end()) {
-                        results.push_back(account_api_object(*itr, _db));
-                        auto vitr = vidx.lower_bound(boost::make_tuple(itr->id, witness_id_type()));
-                        while (vitr != vidx.end() && vitr->account == itr->id) {
-                            results.back().witness_votes.insert(_db.get(vitr->witness).owner);
-                            ++vitr;
-                        }
-                    }
-                    else {
-                        wlog("database_api: No such account with name \"${name}\" in account index", ("name", name) );
-                    }
-                }
-
-                return results;
-            }
-
-            DEFINE_API(plugin, lookup_account_names) {
-                CHECK_ARG_SIZE(1)
-                return my->database().with_weak_read_lock([&]() {
-                    return my->lookup_account_names(args.args->at(0).as<vector<std::string> >());
-                });
-            }
-
-            std::vector<optional<account_api_object>> plugin::api_impl::lookup_account_names(
-                const std::vector<std::string> &account_names
-            ) const {
-                std::vector<optional<account_api_object>> result;
-                result.reserve(account_names.size());
-
-                for (auto &name : account_names) {
-                    auto itr = database().find<account_object, by_name>(name);
-
-                    if (itr) {
-                        result.push_back(account_api_object(*itr, database()));
-                    } else {
-                        result.push_back(optional<account_api_object>());
-                    }
-                }
-
-                return result;
-            }
-
-            DEFINE_API(plugin, lookup_accounts) {
-                CHECK_ARG_SIZE(2)
-                account_name_type lower_bound_name = args.args->at(0).as<account_name_type>();
-                uint32_t limit = args.args->at(1).as<uint32_t>();
-                return my->database().with_weak_read_lock([&]() {
-                    return my->lookup_accounts(lower_bound_name, limit);
-                });
-            }
-
-            std::set<std::string> plugin::api_impl::lookup_accounts(
-                const std::string &lower_bound_name,
-                 uint32_t limit
-            ) const {
-                FC_ASSERT(limit <= 1000);
-                const auto &accounts_by_name = database().get_index<account_index>().indices().get<by_name>();
-                std::set<std::string> result;
-
-                for (auto itr = accounts_by_name.lower_bound(lower_bound_name);
-                     limit-- && itr != accounts_by_name.end(); ++itr) {
-                    result.insert(itr->name);
-                }
-
-                return result;
-            }
-
-            DEFINE_API(plugin, get_account_count) {
-                return my->database().with_weak_read_lock([&]() {
-                    return my->get_account_count();
-                });
-            }
-
-            uint64_t plugin::api_impl::get_account_count() const {
-                return database().get_index<account_index>().indices().size();
-            }
-
-            DEFINE_API(plugin, get_owner_history) {
-                CHECK_ARG_SIZE(1)
-                auto account = args.args->at(0).as<string>();
-                return my->database().with_weak_read_lock([&]() {
-                    std::vector<owner_authority_history_api_object> results;
-                    const auto &hist_idx = my->database().get_index<owner_authority_history_index>().indices().get<
-                            by_account>();
-                    auto itr = hist_idx.lower_bound(account);
-
-                    while (itr != hist_idx.end() && itr->account == account) {
-                        results.push_back(owner_authority_history_api_object(*itr));
-                        ++itr;
-                    }
-
-                    return results;
-                });
-            }
-
-            DEFINE_API(plugin, get_recovery_request) {
-                CHECK_ARG_SIZE(1)
-                auto account = args.args->at(0).as<account_name_type>();
-                return my->database().with_weak_read_lock([&]() {
-                    optional<account_recovery_request_api_object> result;
-
-                    const auto &rec_idx = my->database().get_index<account_recovery_request_index>().indices().get<
-                            by_account>();
-                    auto req = rec_idx.find(account);
-
-                    if (req != rec_idx.end()) {
-                        result = account_recovery_request_api_object(*req);
-                    }
-
-                    return result;
-                });
-            }
-
-            DEFINE_API(plugin, get_escrow) {
-                CHECK_ARG_SIZE(2)
-                auto from = args.args->at(0).as<account_name_type>();
-                auto escrow_id = args.args->at(1).as<uint32_t>();
-                return my->database().with_weak_read_lock([&]() {
-                    optional<escrow_api_object> result;
-
-                    try {
-                        result = my->database().get_escrow(from, escrow_id);
-                    } catch (...) {
-                    }
-
-                    return result;
-                });
-            }
-
-            std::vector<withdraw_route> plugin::api_impl::get_withdraw_routes(
-                std::string account,
-                withdraw_route_type type
-            ) const {
-                std::vector<withdraw_route> result;
-
-                const auto &acc = database().get_account(account);
-
-                if (type == outgoing || type == all) {
-                    const auto &by_route = database().get_index<withdraw_vesting_route_index>().indices().get<
-                            by_withdraw_route>();
-                    auto route = by_route.lower_bound(acc.id);
-
-                    while (route != by_route.end() && route->from_account == acc.id) {
-                        withdraw_route r;
-                        r.from_account = account;
-                        r.to_account = database().get(route->to_account).name;
-                        r.percent = route->percent;
-                        r.auto_vest = route->auto_vest;
-
-                        result.push_back(r);
-
-                        ++route;
-                    }
-                }
-
-                if (type == incoming || type == all) {
-                    const auto &by_dest = database().get_index<withdraw_vesting_route_index>().indices().get<by_destination>();
-                    auto route = by_dest.lower_bound(acc.id);
-
-                    while (route != by_dest.end() && route->to_account == acc.id) {
-                        withdraw_route r;
-                        r.from_account = database().get(route->from_account).name;
-                        r.to_account = account;
-                        r.percent = route->percent;
-                        r.auto_vest = route->auto_vest;
-
-                        result.push_back(r);
-
-                        ++route;
-                    }
-                }
-
-                return result;
-            }
-
-
-            DEFINE_API(plugin, get_withdraw_routes) {
-                FC_ASSERT(args.args->size() == 1 || args.args->size() == 2, "Expected 1-2 arguments, was ${n}",
-                          ("n", args.args->size()));
-                auto account = args.args->at(0).as<string>();
-                auto type = args.args->at(1).as<withdraw_route_type>();
-                return my->database().with_weak_read_lock([&]() {
-                    return my->get_withdraw_routes(account, type);
-                });
-            }
-
-            DEFINE_API(plugin, get_account_bandwidth) {
-                CHECK_ARG_SIZE(2)
-                auto account = args.args->at(0).as<string>();
-                auto type = args.args->at(1).as<bandwidth_type>();
-                optional<account_bandwidth_api_object> result;
-                auto band = my->database().find<account_bandwidth_object, by_account_bandwidth_type>(
-                        boost::make_tuple(account, type));
-                if (band != nullptr) {
-                    result = *band;
-                }
-
-                return result;
-            }
-
-            //////////////////////////////////////////////////////////////////////
-            //                                                                  //
-            // Witnesses                                                        //
-            //                                                                  //
-            //////////////////////////////////////////////////////////////////////
-
-            DEFINE_API(plugin, get_witnesses) {
-                CHECK_ARG_SIZE(1)
-                auto witness_ids = args.args->at(0).as<vector<witness_object::id_type> >();
-                return my->database().with_weak_read_lock([&]() {
-                    return my->get_witnesses(witness_ids);
-                });
-            }
-
-            std::vector<optional<witness_api_object>> plugin::api_impl::get_witnesses(
-                const std::vector<witness_object::id_type> &witness_ids
-            ) const {
-                std::vector<optional<witness_api_object>> result;
-                result.reserve(witness_ids.size());
-                std::transform(witness_ids.begin(), witness_ids.end(), std::back_inserter(result),
-                               [this](witness_object::id_type id) -> optional<witness_api_object> {
-                                   if (auto o = database().find(id)) {
-                                       return *o;
-                                   }
-                                   return {};
-                               });
-                return result;
-            }
-
-            DEFINE_API(plugin, get_witness_by_account) {
-                CHECK_ARG_SIZE(1)
-                auto account_name = args.args->at(0).as<std::string>();
-                return my->database().with_weak_read_lock([&]() {
-                    return my->get_witness_by_account(account_name);
-                });
-            }
-
-
-            fc::optional<witness_api_object> plugin::api_impl::get_witness_by_account(
-                std::string account_name
-            ) const {
-                const auto &idx = database().get_index<witness_index>().indices().get<by_name>();
-                auto itr = idx.find(account_name);
-                if (itr != idx.end()) {
-                    return witness_api_object(*itr);
-                }
-                return {};
-            }
-
-            std::vector<witness_api_object> plugin::api_impl::get_witnesses_by_vote(
-                std::string from,
-                uint32_t limit
-            ) const {
-                //idump((from)(limit));
-                FC_ASSERT(limit <= 100);
-
-                std::vector<witness_api_object> result;
-                result.reserve(limit);
-
-                const auto &name_idx = database().get_index<witness_index>().indices().get<by_name>();
-                const auto &vote_idx = database().get_index<witness_index>().indices().get<by_vote_name>();
-
-                auto itr = vote_idx.begin();
-                if (from.size()) {
-                    auto nameitr = name_idx.find(from);
-                    FC_ASSERT(nameitr != name_idx.end(), "invalid witness name ${n}", ("n", from));
-                    itr = vote_idx.iterator_to(*nameitr);
-                }
-
-                while (itr != vote_idx.end() && result.size() < limit && itr->votes > 0) {
-                    result.push_back(witness_api_object(*itr));
-                    ++itr;
-                }
-                return result;
-
-            }
-
-            DEFINE_API(plugin, get_witnesses_by_vote) {
-                CHECK_ARG_SIZE(2)
-                auto from = args.args->at(0).as<std::string>();
-                auto limit = args.args->at(1).as<uint32_t>();
-                return my->database().with_weak_read_lock([&]() {
-                    return my->get_witnesses_by_vote(from, limit);
-                });
-            }
-
-
-            DEFINE_API(plugin, lookup_witness_accounts) {
-                CHECK_ARG_SIZE(2)
-                auto lower_bound_name = args.args->at(0).as<std::string>();
-                auto limit = args.args->at(1).as<uint32_t>();
-                return my->database().with_weak_read_lock([&]() {
-                    return my->lookup_witness_accounts(lower_bound_name, limit);
-                });
-            }
-
-            std::set<account_name_type> plugin::api_impl::lookup_witness_accounts(
-                const std::string &lower_bound_name,
-                uint32_t limit
-            ) const {
-                FC_ASSERT(limit <= 1000);
-                const auto &witnesses_by_id = database().get_index<witness_index>().indices().get<by_id>();
-
-                // get all the names and look them all up, sort them, then figure out what
-                // records to return.  This could be optimized, but we expect the
-                // number of witnesses to be few and the frequency of calls to be rare
-                std::set<account_name_type> witnesses_by_account_name;
-                for (const witness_api_object &witness : witnesses_by_id) {
-                    if (witness.owner >= lower_bound_name) { // we can ignore anything below lower_bound_name
-                        witnesses_by_account_name.insert(witness.owner);
-                    }
-                }
-
-                auto end_iter = witnesses_by_account_name.begin();
-                while (end_iter != witnesses_by_account_name.end() && limit--) {
-                    ++end_iter;
-                }
-                witnesses_by_account_name.erase(end_iter, witnesses_by_account_name.end());
-                return witnesses_by_account_name;
-            }
-
-            DEFINE_API(plugin, get_witness_count) {
-                return my->database().with_weak_read_lock([&]() {
-                    return my->get_witness_count();
-                });
-            }
-
-            uint64_t plugin::api_impl::get_witness_count() const {
-                return database().get_index<witness_index>().indices().size();
-            }
-
-            //////////////////////////////////////////////////////////////////////
-            //                                                                  //
-            // Authority / validation                                           //
-            //                                                                  //
-            //////////////////////////////////////////////////////////////////////
-
-            DEFINE_API(plugin, get_transaction_hex) {
-                CHECK_ARG_SIZE(1)
-                auto trx = args.args->at(0).as<signed_transaction>();
-                return my->database().with_weak_read_lock([&]() {
-                    return my->get_transaction_hex(trx);
-                });
-            }
-
-            std::string plugin::api_impl::get_transaction_hex(const signed_transaction &trx) const {
-                return fc::to_hex(fc::raw::pack(trx));
-            }
-
-            DEFINE_API(plugin, get_required_signatures) {
-                CHECK_ARG_SIZE(2)
-                auto trx = args.args->at(0).as<signed_transaction>();
-                auto available_keys = args.args->at(1).as<flat_set<public_key_type>>();
-                return my->database().with_weak_read_lock([&]() {
-                    return my->get_required_signatures(trx, available_keys);
-                });
-            }
-
-            std::set<public_key_type> plugin::api_impl::get_required_signatures(
-                const signed_transaction &trx,
-                const flat_set<public_key_type> &available_keys
-            ) const {
-                //   wdump((trx)(available_keys));
-                auto result = trx.get_required_signatures(
-                    STEEMIT_CHAIN_ID, available_keys,
-                    [&](std::string account_name) {
-                        return authority(database().get<account_authority_object, by_account>(account_name).active);
-                    },
-                    [&](std::string account_name) {
-                        return authority(database().get<account_authority_object, by_account>(account_name).owner);
-                    },
-                    [&](std::string account_name) {
-                        return authority(database().get<account_authority_object, by_account>(account_name).posting);
-                    },
-                    STEEMIT_MAX_SIG_CHECK_DEPTH
-                );
-                //   wdump((result));
-                return result;
-            }
-
-            DEFINE_API(plugin, get_potential_signatures) {
-                CHECK_ARG_SIZE(1)
-                return my->database().with_weak_read_lock([&]() {
-                    return my->get_potential_signatures(args.args->at(0).as<signed_transaction>());
-                });
-            }
-
-            std::set<public_key_type> plugin::api_impl::get_potential_signatures(const signed_transaction &trx) const {
-                //   wdump((trx));
-                std::set<public_key_type> result;
-                trx.get_required_signatures(STEEMIT_CHAIN_ID, flat_set<public_key_type>(),
-                    [&](account_name_type account_name) {
-                        const auto &auth = database().get<account_authority_object, by_account>(account_name).active;
-                        for (const auto &k : auth.get_keys()) {
-                            result.insert(k);
-                        }
-                        return authority(auth);
-                    },
-                    [&](account_name_type account_name) {
-                        const auto &auth = database().get<account_authority_object, by_account>(account_name).owner;
-                        for (const auto &k : auth.get_keys()) {
-                            result.insert(k);
-                        }
-                        return authority(auth);
-                    },
-                    [&](account_name_type account_name) {
-                        const auto &auth = database().get<account_authority_object, by_account>(account_name).posting;
-                        for (const auto &k : auth.get_keys()) {
-                            result.insert(k);
-                        }
-                        return authority(auth);
-                    },
-                    STEEMIT_MAX_SIG_CHECK_DEPTH
-                );
-
-                //   wdump((result));
-                return result;
-            }
-
-            DEFINE_API(plugin, verify_authority) {
-                CHECK_ARG_SIZE(1)
-                return my->database().with_weak_read_lock([&]() {
-                    return my->verify_authority(args.args->at(0).as<signed_transaction>());
-                });
-            }
-
-            bool plugin::api_impl::verify_authority(const signed_transaction &trx) const {
-                trx.verify_authority(STEEMIT_CHAIN_ID, [&](std::string account_name) {
-                    return authority(database().get<account_authority_object, by_account>(account_name).active);
-                }, [&](std::string account_name) {
-                    return authority(database().get<account_authority_object, by_account>(account_name).owner);
-                }, [&](std::string account_name) {
-                    return authority(database().get<account_authority_object, by_account>(account_name).posting);
-                }, STEEMIT_MAX_SIG_CHECK_DEPTH);
-                return true;
-            }
-
-            DEFINE_API(plugin, verify_account_authority) {
-                CHECK_ARG_SIZE(2)
-                return my->database().with_weak_read_lock([&]() {
-                    return my->verify_account_authority(args.args->at(0).as<account_name_type>(),
-                                                        args.args->at(1).as<flat_set<public_key_type> >());
-                });
-            }
-
-            bool plugin::api_impl::verify_account_authority(
-                const std::string &name,
-                const flat_set<public_key_type> &keys
-            ) const {
-                FC_ASSERT(name.size() > 0);
-                auto account = database().find<account_object, by_name>(name);
-                FC_ASSERT(account, "no such account");
-
-                /// reuse trx.verify_authority by creating a dummy transfer
-                signed_transaction trx;
-                transfer_operation op;
-                op.from = account->name;
-                trx.operations.emplace_back(op);
-
-                return verify_authority(trx);
-            }
-
-            DEFINE_API(plugin, get_conversion_requests) {
-                CHECK_ARG_SIZE(1)
-                auto account = args.args->at(0).as<std::string>();
-                return my->database().with_weak_read_lock([&]() {
-                    const auto &idx = my->database().get_index<convert_request_index>().indices().get<by_owner>();
-                    std::vector<convert_request_api_object> result;
-                    auto itr = idx.lower_bound(account);
-                    while (itr != idx.end() && itr->owner == account) {
-                        result.emplace_back(*itr);
-                        ++itr;
-                    }
-                    return result;
-                });
-            }
-
-
-            std::vector<account_name_type> plugin::api_impl::get_miner_queue() const {
-                std::vector<account_name_type> result;
-                const auto &pow_idx = database().get_index<witness_index>().indices().get<by_pow>();
-
-                auto itr = pow_idx.upper_bound(0);
-                while (itr != pow_idx.end()) {
-                    if (itr->pow_worker) {
-                        result.push_back(itr->owner);
-                    }
-                    ++itr;
-                }
-                return result;
-            }
-
-
-            DEFINE_API(plugin, get_miner_queue) {
-                return my->database().with_weak_read_lock([&]() {
-                    return my->get_miner_queue();
-                });
-            }
-
-            DEFINE_API(plugin, get_active_witnesses) {
-                return my->database().with_weak_read_lock([&]() {
-                    const auto &wso = my->database().get_witness_schedule_object();
-                    size_t n = wso.current_shuffled_witnesses.size();
-                    vector<account_name_type> result;
-                    result.reserve(n);
-                    for (size_t i = 0; i < n; i++) {
-                        if (wso.current_shuffled_witnesses[i] != "") {
-                            result.push_back(wso.current_shuffled_witnesses[i]);
-                        }
-                    }
-                    return result;
-                });
-            }
-
-
-            DEFINE_API(plugin, get_savings_withdraw_from) {
-                CHECK_ARG_SIZE(1)
-                auto account = args.args->at(0).as<string>();
-                return my->database().with_weak_read_lock([&]() {
-                    std::vector<savings_withdraw_api_object> result;
-
-                    const auto &from_rid_idx = my->database().get_index<savings_withdraw_index>().indices().get<by_from_rid>();
-                    auto itr = from_rid_idx.lower_bound(account);
-                    while (itr != from_rid_idx.end() && itr->from == account) {
-                        result.push_back(savings_withdraw_api_object(*itr));
-                        ++itr;
-                    }
-                    return result;
-                });
-            }
-
-            DEFINE_API(plugin, get_savings_withdraw_to) {
-                CHECK_ARG_SIZE(1)
-                auto account = args.args->at(0).as<string>();
-                return my->database().with_weak_read_lock([&]() {
-                    std::vector<savings_withdraw_api_object> result;
-
-                    const auto &to_complete_idx = my->database().get_index<savings_withdraw_index>().indices().get<by_to_complete>();
-                    auto itr = to_complete_idx.lower_bound(account);
-                    while (itr != to_complete_idx.end() && itr->to == account) {
-                        result.push_back(savings_withdraw_api_object(*itr));
-                        ++itr;
-                    }
-                    return result;
-                });
-            }
-
-            //vector<vesting_delegation_api_obj> get_vesting_delegations(string account, string from, uint32_t limit, delegations_type type = delegated) const;
-            DEFINE_API(plugin, get_vesting_delegations) {
-                size_t n_args = args.args->size();
-                CHECK_ARGS_COUNT(2, 4);
-                auto account = args.args->at(0).as<string>();
-                auto from = args.args->at(1).as<string>();
-                auto limit = n_args >= 3 ? args.args->at(2).as<uint32_t>() : 100;
-                auto type = n_args >= 4 ? args.args->at(3).as<delegations_type>() : delegated;
-                bool sent = type == delegated;
-                FC_ASSERT(limit <= 1000);
-
-                vector<vesting_delegation_api_object> result;
-                result.reserve(limit);
-                return my->database().with_weak_read_lock([&]() {
-                    auto fill_result = [&](const auto& idx) {
-                        auto i = idx.lower_bound(std::make_tuple(account, from));
-                        while (result.size() < limit && i != idx.end() && account == (sent ? i->delegator : i->delegatee)) {
-                            result.push_back(*i++);
-                        }
-                    };
-                    if (sent)
-                        fill_result(my->database().get_index<vesting_delegation_index, by_delegation>());
-                    else
-                        fill_result(my->database().get_index<vesting_delegation_index, by_received>());
-                    return result;
-                });
-            }
-
-            //vector<vesting_delegation_expiration_api_obj> get_expiring_vesting_delegations(string account, time_point_sec from, uint32_t limit = 100) const;
-            DEFINE_API(plugin, get_expiring_vesting_delegations) {
-                size_t n_args = args.args->size();
-                CHECK_ARGS_COUNT(2, 3);
-                auto account = args.args->at(0).as<string>();
-                auto from = args.args->at(1).as<time_point_sec>();
-                uint32_t limit = n_args >= 3 ? args.args->at(2).as<uint32_t>() : 100;
-                FC_ASSERT(limit <= 1000);
-
-                return my->database().with_weak_read_lock([&]() {
-                    vector<vesting_delegation_expiration_api_object> result;
-                    result.reserve(limit);
-                    const auto& idx = my->database().get_index<vesting_delegation_expiration_index, by_account_expiration>();
-                    auto itr = idx.lower_bound(std::make_tuple(account, from));
-                    while (result.size() < limit && itr != idx.end() && itr->delegator == account) {
-                        result.push_back(*itr);
-                        ++itr;
-                    }
-                    return result;
-                });
-            }
-
-            DEFINE_API(plugin, get_database_info) {
-                CHECK_ARG_SIZE(0);
-
-                // read lock doesn't seem needed...
-
-                database_info info;
-                auto& db = my->database();
-
-                info.free_size = db.free_memory();
-                info.total_size = db.max_memory();
-                info.reserved_size = db.reserved_memory();
-                info.used_size = info.total_size - info.free_size - info.reserved_size;
-
-                info.index_list.reserve(db.index_list_size());
-
-                for (auto it = db.index_list_begin(), et = db.index_list_end(); et != it; ++it) {
-                    info.index_list.push_back({(*it)->name(), (*it)->size()});
-                }
-
-                return info;
-            }
-
-            std::vector<proposal_api_object> plugin::api_impl::get_proposed_transactions(
-                const std::string& a, uint32_t from, uint32_t limit
-            ) const {
-                std::vector<proposal_api_object> result;
-                std::set<proposal_object_id_type> id_set;
-                result.reserve(limit);
-
-                // list of published proposals
-                {
-                    auto& idx = database().get_index<proposal_index>().indices().get<by_account>();
-                    auto itr = idx.lower_bound(a);
-
-                    for (; idx.end() != itr && itr->author == a && result.size() < limit; ++itr) {
-                        id_set.insert(itr->id);
-                        if (id_set.size() >= from) {
-                            result.emplace_back(*itr);
-                        }
-                    }
-                }
-
-                // list of requested proposals
-                if (result.size() < limit) {
-                    auto& idx = database().get_index<required_approval_index>().indices().get<by_account>();
-                    auto& pidx = database().get_index<proposal_index>().indices().get<by_id>();
-                    auto itr = idx.lower_bound(a);
-
-                    for (; idx.end() != itr && itr->account == a && result.size() < limit; ++itr) {
-                        if (!id_set.count(itr->proposal)) {
-                            id_set.insert(itr->proposal);
-                            auto pitr = pidx.find(itr->proposal);
-                            if (pidx.end() != pitr && id_set.size() >= from) {
-                                result.emplace_back(*pitr);
-                            }
-                        }
-                    }
-                }
-
-                return result;
-            }
-
-            DEFINE_API(plugin, get_proposed_transactions) {
-                CHECK_ARG_SIZE(3);
-                auto account = args.args->at(0).as<string>();
-                auto from = args.args->at(1).as<uint32_t>();
-                auto limit = args.args->at(2).as<uint32_t>();
-                FC_ASSERT(limit <= 100);
-
-                return my->database().with_weak_read_lock([&]() {
-                    return my->get_proposed_transactions(account, from, limit);
-                });
-            }
-
-            void plugin::plugin_initialize(const boost::program_options::variables_map &options) {
-                ilog("database_api plugin: plugin_initialize() begin");
-                my = std::make_unique<api_impl>();
-                JSON_RPC_REGISTER_API(plugin_name)
-                my->database().applied_block.connect([this](const protocol::signed_block &) {
-                    this->clear_block_applied_callback();
-                });
-                ilog("database_api plugin: plugin_initialize() end");
-            }
-
-            void plugin::plugin_startup() {
-                my->startup();
             }
+        }
+    }
+
+    return result;
+}
+
+DEFINE_API(plugin, get_proposed_transactions) {
+    CHECK_ARG_SIZE(3);
+    auto account = args.args->at(0).as<string>();
+    auto from = args.args->at(1).as<uint32_t>();
+    auto limit = args.args->at(2).as<uint32_t>();
+    FC_ASSERT(limit <= 100);
+
+    return my->database().with_weak_read_lock([&]() {
+        return my->get_proposed_transactions(account, from, limit);
+    });
+}
+
+void plugin::plugin_initialize(const boost::program_options::variables_map &options) {
+    ilog("database_api plugin: plugin_initialize() begin");
+    my = std::make_unique<api_impl>();
+    JSON_RPC_REGISTER_API(plugin_name)
+    my->database().applied_block.connect([this](const protocol::signed_block &) {
+        this->clear_block_applied_callback();
+    });
+    ilog("database_api plugin: plugin_initialize() end");
+}
+
+void plugin::plugin_startup() {
+    my->startup();
+}
 
 } } } // golos::plugins::database_api

--- a/plugins/database_api/api.cpp
+++ b/plugins/database_api/api.cpp
@@ -930,7 +930,8 @@ DEFINE_API(plugin, get_vesting_delegations) {
         auto fill_result = [&](const auto& idx) {
             auto i = idx.lower_bound(std::make_tuple(account, from));
             while (result.size() < limit && i != idx.end() && account == (sent ? i->delegator : i->delegatee)) {
-                result.push_back(*i++);
+                result.push_back(*i);
+                ++i;
             }
         };
         if (sent)

--- a/plugins/database_api/include/golos/plugins/database_api/plugin.hpp
+++ b/plugins/database_api/include/golos/plugins/database_api/plugin.hpp
@@ -20,403 +20,400 @@
 #include "forward.hpp"
 
 namespace golos { namespace plugins { namespace database_api {
-            using namespace golos::chain;
-            using namespace golos::protocol;
-            using fc::variant;
-            using std::vector;
-            using plugins::json_rpc::void_type;
-            using plugins::json_rpc::msg_pack;
-            using plugins::json_rpc::msg_pack_transfer;
-
-            struct database_index_info {
-                std::string name;
-                std::size_t record_count;
-            };
-
-            struct database_info {
-                std::size_t total_size;
-                std::size_t free_size;
-                std::size_t reserved_size;
-                std::size_t used_size;
-
-                std::vector<database_index_info> index_list;
-            };
-
-            struct scheduled_hardfork {
-                hardfork_version hf_version;
-                fc::time_point_sec live_time;
-            };
-
-            struct withdraw_route {
-                std::string from_account;
-                std::string to_account;
-                uint16_t percent;
-                bool auto_vest;
-            };
-
-            enum withdraw_route_type {
-                incoming, outgoing, all
-            };
-
-            enum delegations_type {
-                delegated, received
-            };
-
-
-            struct tag_count_object {
-                string tag;
-                uint32_t count;
-            };
-
-            struct get_tags_used_by_author {
-                vector<tag_count_object> tags;
-            };
-
-            struct signed_block_api_object : public signed_block {
-                signed_block_api_object(const signed_block &block) : signed_block(block) {
-                    block_id = id();
-                    signing_key = signee();
-                    transaction_ids.reserve(transactions.size());
-                    for (const signed_transaction &tx : transactions) {
-                        transaction_ids.push_back(tx.id());
-                    }
-                }
-
-                signed_block_api_object() {
-                }
-
-                block_id_type block_id;
-                public_key_type signing_key;
-                vector<transaction_id_type> transaction_ids;
-            };
-
-
-            using chain_properties_17 = chain_properties;
-            using price_17 = price;
-
-            using block_applied_callback = std::function<void(const variant &block_header)>;
-
-            ///               API,                                    args,                return
-            DEFINE_API_ARGS(get_active_witnesses,             msg_pack, std::vector<account_name_type>)
-            DEFINE_API_ARGS(get_block_header,                 msg_pack, optional<block_header>)
-            DEFINE_API_ARGS(get_block,                        msg_pack, optional<signed_block>)
-            DEFINE_API_ARGS(set_block_applied_callback,       msg_pack, void_type)
-            DEFINE_API_ARGS(get_config,                       msg_pack, variant_object)
-            DEFINE_API_ARGS(get_dynamic_global_properties,    msg_pack, dynamic_global_property_api_object)
-            DEFINE_API_ARGS(get_chain_properties,             msg_pack, chain_properties_17)
-            DEFINE_API_ARGS(get_current_median_history_price, msg_pack, price_17)
-            DEFINE_API_ARGS(get_feed_history,                 msg_pack, feed_history_api_object)
-            DEFINE_API_ARGS(get_witness_schedule,             msg_pack, witness_schedule_api_object)
-            DEFINE_API_ARGS(get_hardfork_version,             msg_pack, hardfork_version)
-            DEFINE_API_ARGS(get_next_scheduled_hardfork,      msg_pack, scheduled_hardfork)
-            DEFINE_API_ARGS(get_accounts,                     msg_pack, std::vector<account_api_object>)
-            DEFINE_API_ARGS(lookup_account_names,             msg_pack, std::vector<optional<account_api_object> >)
-            DEFINE_API_ARGS(lookup_accounts,                  msg_pack, std::set<std::string>)
-            DEFINE_API_ARGS(get_account_count,                msg_pack, uint64_t)
-            DEFINE_API_ARGS(get_owner_history,                msg_pack, std::vector<owner_authority_history_api_object>)
-            DEFINE_API_ARGS(get_recovery_request,             msg_pack, optional<account_recovery_request_api_object>)
-            DEFINE_API_ARGS(get_escrow,                       msg_pack, optional<escrow_api_object>)
-            DEFINE_API_ARGS(get_withdraw_routes,              msg_pack, std::vector<withdraw_route>)
-            DEFINE_API_ARGS(get_account_bandwidth,            msg_pack, optional<account_bandwidth_api_object>)
-            DEFINE_API_ARGS(get_savings_withdraw_from,        msg_pack, std::vector<savings_withdraw_api_object>)
-            DEFINE_API_ARGS(get_savings_withdraw_to,          msg_pack, std::vector<savings_withdraw_api_object>)
-
-            DEFINE_API_ARGS(get_vesting_delegations,          msg_pack, vector<vesting_delegation_api_object>)
-            DEFINE_API_ARGS(get_expiring_vesting_delegations, msg_pack, vector<vesting_delegation_expiration_api_object>)
 
-            DEFINE_API_ARGS(get_witnesses,                    msg_pack, std::vector<optional<witness_api_object> >)
-            DEFINE_API_ARGS(get_conversion_requests,          msg_pack, std::vector<convert_request_api_object>)
-            DEFINE_API_ARGS(get_witness_by_account,           msg_pack, optional<witness_api_object>)
-            DEFINE_API_ARGS(get_witnesses_by_vote,            msg_pack, std::vector<witness_api_object>)
-            DEFINE_API_ARGS(lookup_witness_accounts,          msg_pack, std::set<account_name_type>)
-            DEFINE_API_ARGS(get_open_orders,                  msg_pack, std::vector<extended_limit_order>)
-            DEFINE_API_ARGS(get_witness_count,                msg_pack, uint64_t)
-            DEFINE_API_ARGS(get_transaction_hex,              msg_pack, std::string)
-            DEFINE_API_ARGS(get_required_signatures,          msg_pack, std::set<public_key_type>)
-            DEFINE_API_ARGS(get_potential_signatures,         msg_pack, std::set<public_key_type>)
-            DEFINE_API_ARGS(verify_authority,                 msg_pack, bool)
-            DEFINE_API_ARGS(verify_account_authority,         msg_pack, bool)
-            DEFINE_API_ARGS(get_miner_queue,                  msg_pack, std::vector<account_name_type>)
-            DEFINE_API_ARGS(get_database_info,                msg_pack, database_info)
-            DEFINE_API_ARGS(get_proposed_transactions,        msg_pack, std::vector<proposal_api_object>)
+using namespace golos::chain;
+using namespace golos::protocol;
+using fc::variant;
+using std::vector;
+using plugins::json_rpc::void_type;
+using plugins::json_rpc::msg_pack;
+using plugins::json_rpc::msg_pack_transfer;
+
+struct database_index_info {
+    std::string name;
+    std::size_t record_count;
+};
+
+struct database_info {
+    std::size_t total_size;
+    std::size_t free_size;
+    std::size_t reserved_size;
+    std::size_t used_size;
+
+    std::vector<database_index_info> index_list;
+};
+
+struct scheduled_hardfork {
+    hardfork_version hf_version;
+    fc::time_point_sec live_time;
+};
+
+struct withdraw_route {
+    std::string from_account;
+    std::string to_account;
+    uint16_t percent;
+    bool auto_vest;
+};
+
+enum withdraw_route_type {
+    incoming, outgoing, all
+};
+
+enum delegations_type {
+    delegated, received
+};
+
+
+struct tag_count_object {
+    string tag;
+    uint32_t count;
+};
+
+struct get_tags_used_by_author {
+    vector<tag_count_object> tags;
+};
+
+struct signed_block_api_object : public signed_block {
+    signed_block_api_object(const signed_block &block) : signed_block(block) {
+        block_id = id();
+        signing_key = signee();
+        transaction_ids.reserve(transactions.size());
+        for (const signed_transaction &tx : transactions) {
+            transaction_ids.push_back(tx.id());
+        }
+    }
+
+    signed_block_api_object() {
+    }
+
+    block_id_type block_id;
+    public_key_type signing_key;
+    vector<transaction_id_type> transaction_ids;
+};
+
+
+using chain_properties_17 = chain_properties;
+using price_17 = price;
+
+using block_applied_callback = std::function<void(const variant &block_header)>;
+
+///               API,                                    args,                return
+DEFINE_API_ARGS(get_active_witnesses,             msg_pack, std::vector<account_name_type>)
+DEFINE_API_ARGS(get_block_header,                 msg_pack, optional<block_header>)
+DEFINE_API_ARGS(get_block,                        msg_pack, optional<signed_block>)
+DEFINE_API_ARGS(set_block_applied_callback,       msg_pack, void_type)
+DEFINE_API_ARGS(get_config,                       msg_pack, variant_object)
+DEFINE_API_ARGS(get_dynamic_global_properties,    msg_pack, dynamic_global_property_api_object)
+DEFINE_API_ARGS(get_chain_properties,             msg_pack, chain_properties_17)
+DEFINE_API_ARGS(get_current_median_history_price, msg_pack, price_17)
+DEFINE_API_ARGS(get_feed_history,                 msg_pack, feed_history_api_object)
+DEFINE_API_ARGS(get_witness_schedule,             msg_pack, witness_schedule_api_object)
+DEFINE_API_ARGS(get_hardfork_version,             msg_pack, hardfork_version)
+DEFINE_API_ARGS(get_next_scheduled_hardfork,      msg_pack, scheduled_hardfork)
+DEFINE_API_ARGS(get_accounts,                     msg_pack, std::vector<account_api_object>)
+DEFINE_API_ARGS(lookup_account_names,             msg_pack, std::vector<optional<account_api_object> >)
+DEFINE_API_ARGS(lookup_accounts,                  msg_pack, std::set<std::string>)
+DEFINE_API_ARGS(get_account_count,                msg_pack, uint64_t)
+DEFINE_API_ARGS(get_owner_history,                msg_pack, std::vector<owner_authority_history_api_object>)
+DEFINE_API_ARGS(get_recovery_request,             msg_pack, optional<account_recovery_request_api_object>)
+DEFINE_API_ARGS(get_escrow,                       msg_pack, optional<escrow_api_object>)
+DEFINE_API_ARGS(get_withdraw_routes,              msg_pack, std::vector<withdraw_route>)
+DEFINE_API_ARGS(get_account_bandwidth,            msg_pack, optional<account_bandwidth_api_object>)
+DEFINE_API_ARGS(get_savings_withdraw_from,        msg_pack, std::vector<savings_withdraw_api_object>)
+DEFINE_API_ARGS(get_savings_withdraw_to,          msg_pack, std::vector<savings_withdraw_api_object>)
 
+DEFINE_API_ARGS(get_vesting_delegations,          msg_pack, vector<vesting_delegation_api_object>)
+DEFINE_API_ARGS(get_expiring_vesting_delegations, msg_pack, vector<vesting_delegation_expiration_api_object>)
 
-            /**
-             * @brief The database_api class implements the RPC API for the chain database.
-             *
-             * This API exposes accessors on the database which query state tracked by a blockchain validating node. This API is
-             * read-only; all modifications to the database must be performed via transactions. Transactions are broadcast via
-             * the @ref network_broadcast_api.
-             */
-            class plugin final : public appbase::plugin<plugin> {
-            public:
-                constexpr static const char *plugin_name = "database_api";
+DEFINE_API_ARGS(get_witnesses,                    msg_pack, std::vector<optional<witness_api_object> >)
+DEFINE_API_ARGS(get_conversion_requests,          msg_pack, std::vector<convert_request_api_object>)
+DEFINE_API_ARGS(get_witness_by_account,           msg_pack, optional<witness_api_object>)
+DEFINE_API_ARGS(get_witnesses_by_vote,            msg_pack, std::vector<witness_api_object>)
+DEFINE_API_ARGS(lookup_witness_accounts,          msg_pack, std::set<account_name_type>)
+DEFINE_API_ARGS(get_open_orders,                  msg_pack, std::vector<extended_limit_order>)
+DEFINE_API_ARGS(get_witness_count,                msg_pack, uint64_t)
+DEFINE_API_ARGS(get_transaction_hex,              msg_pack, std::string)
+DEFINE_API_ARGS(get_required_signatures,          msg_pack, std::set<public_key_type>)
+DEFINE_API_ARGS(get_potential_signatures,         msg_pack, std::set<public_key_type>)
+DEFINE_API_ARGS(verify_authority,                 msg_pack, bool)
+DEFINE_API_ARGS(verify_account_authority,         msg_pack, bool)
+DEFINE_API_ARGS(get_miner_queue,                  msg_pack, std::vector<account_name_type>)
+DEFINE_API_ARGS(get_database_info,                msg_pack, database_info)
+DEFINE_API_ARGS(get_proposed_transactions,        msg_pack, std::vector<proposal_api_object>)
+
+
+/**
+ * @brief The database_api class implements the RPC API for the chain database.
+ *
+ * This API exposes accessors on the database which query state tracked by a blockchain validating node. This API is
+ * read-only; all modifications to the database must be performed via transactions. Transactions are broadcast via
+ * the @ref network_broadcast_api.
+ */
+class plugin final : public appbase::plugin<plugin> {
+public:
+    constexpr static const char *plugin_name = "database_api";
 
-                static const std::string &name() {
-                    static std::string name = plugin_name;
-                    return name;
-                }
+    static const std::string &name() {
+        static std::string name = plugin_name;
+        return name;
+    }
 
-                APPBASE_PLUGIN_REQUIRES(
-                        (json_rpc::plugin)
-                        (chain::plugin)
-                )
+    APPBASE_PLUGIN_REQUIRES(
+            (json_rpc::plugin)
+            (chain::plugin)
+    )
 
-                void set_program_options(boost::program_options::options_description &cli, boost::program_options::options_description &cfg) override{}
+    void set_program_options(boost::program_options::options_description &cli, boost::program_options::options_description &cfg) override{}
 
-                void plugin_initialize(const boost::program_options::variables_map &options) override;
+    void plugin_initialize(const boost::program_options::variables_map &options) override;
 
-                void plugin_startup() override;
+    void plugin_startup() override;
 
-                void plugin_shutdown() override{}
+    void plugin_shutdown() override{}
 
-                plugin();
+    plugin();
 
-                ~plugin();
+    ~plugin();
 
-                ///////////////////
-                // Subscriptions //
-                ///////////////////
+    ///////////////////
+    // Subscriptions //
+    ///////////////////
 
-                void set_subscribe_callback(std::function<void(const variant &)> cb, bool clear_filter);
+    void set_subscribe_callback(std::function<void(const variant &)> cb, bool clear_filter);
 
-                void set_pending_transaction_callback(std::function<void(const variant &)> cb);
+    void set_pending_transaction_callback(std::function<void(const variant &)> cb);
 
-                /**
-                 * @brief Stop receiving any notifications
-                 *
-                 * This unsubscribes from all subscribed markets and objects.
-                 */
-                void cancel_all_subscriptions();
+    /**
+     * @brief Stop receiving any notifications
+     *
+     * This unsubscribes from all subscribed markets and objects.
+     */
+    void cancel_all_subscriptions();
+
+
+    /**
+     * @brief Clear disconnected callbacks on applied block
+     */
 
+    void clear_block_applied_callback();
 
-                /**
-                 * @brief Clear disconnected callbacks on applied block
-                 */
+    DECLARE_API(
+        /**
+         *  This API is a short-cut for returning all of the state required for a particular URL
+         *  with a single query.
+         */
 
-                void clear_block_applied_callback();
 
-                DECLARE_API(
+        (get_active_witnesses)
 
-                                    /**
-                                     *  This API is a short-cut for returning all of the state required for a particular URL
-                                     *  with a single query.
-                                     */
+        (get_miner_queue)
 
+        /////////////////////////////
+        // Blocks and transactions //
+        /////////////////////////////
 
+        /**
+         * @brief Retrieve a block header
+         * @param block_num Height of the block whose header should be returned
+         * @return header of the referenced block, or null if no matching block was found
+         */
+        (get_block_header)
 
-                                    (get_active_witnesses)
+        /**
+         * @brief Retrieve a full, signed block
+         * @param block_num Height of the block to be returned
+         * @return the referenced block, or null if no matching block was found
+         */
+        (get_block)
 
-                                    (get_miner_queue)
+        /**
+         * @brief Set callback which is triggered on each generated block
+         * @param callback function which should be called
+         */
+        (set_block_applied_callback)
 
-                                    /////////////////////////////
-                                    // Blocks and transactions //
-                                    /////////////////////////////
+        /////////////
+        // Globals //
+        /////////////
 
-                                    /**
-                                     * @brief Retrieve a block header
-                                     * @param block_num Height of the block whose header should be returned
-                                     * @return header of the referenced block, or null if no matching block was found
-                                     */
+        /**
+         * @brief Retrieve compile-time constants
+         */
+        (get_config)
 
-                                    (get_block_header)
+        /**
+         * @brief Retrieve the current @ref dynamic_global_property_object
+         */
+        (get_dynamic_global_properties)
 
-                                    /**
-                                     * @brief Retrieve a full, signed block
-                                     * @param block_num Height of the block to be returned
-                                     * @return the referenced block, or null if no matching block was found
-                                     */
-                                    (get_block)
+        (get_chain_properties)
 
-                                    /**
-                                     * @brief Set callback which is triggered on each generated block
-                                     * @param callback function which should be called
-                                     */
-                                    (set_block_applied_callback)
+        (get_current_median_history_price)
 
-                                    /////////////
-                                    // Globals //
-                                    /////////////
+        (get_feed_history)
 
-                                    /**
-                                     * @brief Retrieve compile-time constants
-                                     */
-                                    (get_config)
+        (get_witness_schedule)
+
+        (get_hardfork_version)
+
+        (get_next_scheduled_hardfork)
+
+
+        //////////////
+        // Accounts //
+        //////////////
+
+        (get_accounts)
+        /**
+         * @brief Get a list of accounts by name
+         * @param account_names Names of the accounts to retrieve
+         * @return The accounts holding the provided names
+         *
+         * This function has semantics identical to @ref get_objects
+         */
+        (lookup_account_names)
 
-                                    /**
-                                     * @brief Retrieve the current @ref dynamic_global_property_object
-                                     */
-                                    (get_dynamic_global_properties)
+        /**
+         * @brief Get names and IDs for registered accounts
+         * @param lower_bound_name Lower bound of the first name to return
+         * @param limit Maximum number of results to return -- must not exceed 1000
+         * @return Map of account names to corresponding IDs
+         */
+        (lookup_accounts)
 
-                                    (get_chain_properties)
+        //////////////
+        // Balances //
+        //////////////
 
-                                    (get_current_median_history_price)
+        /**
+         * @brief Get an account's balances in various assets
+         * @param name of the account to get balances for
+         * @param assets names of the assets to get balances of; if empty, get all assets account has a balance in
+         * @return Balances of the account
+         */
 
-                                    (get_feed_history)
 
-                                    (get_witness_schedule)
+        /**
+         * @brief Get the total number of accounts registered with the blockchain
+         */
+        (get_account_count)
+
+        (get_owner_history)
 
-                                    (get_hardfork_version)
+        (get_recovery_request)
 
-                                    (get_next_scheduled_hardfork)
+        (get_escrow)
 
+        (get_withdraw_routes)
 
-                                    //////////////
-                                    // Accounts //
-                                    //////////////
+        (get_account_bandwidth)
 
-                                    (get_accounts)
-                                    /**
-                                     * @brief Get a list of accounts by name
-                                     * @param account_names Names of the accounts to retrieve
-                                     * @return The accounts holding the provided names
-                                     *
-                                     * This function has semantics identical to @ref get_objects
-                                     */
-                                    (lookup_account_names)
+        (get_savings_withdraw_from)
 
-                                    /**
-                                     * @brief Get names and IDs for registered accounts
-                                     * @param lower_bound_name Lower bound of the first name to return
-                                     * @param limit Maximum number of results to return -- must not exceed 1000
-                                     * @return Map of account names to corresponding IDs
-                                     */
-                                    (lookup_accounts)
+        (get_savings_withdraw_to)
 
-                                    //////////////
-                                    // Balances //
-                                    //////////////
+        (get_vesting_delegations)
+        (get_expiring_vesting_delegations)
+        // (list_vesting_delegations)
+        // (find_vesting_delegations)
+        // (list_vesting_delegation_expirations)
+        // (find_vesting_delegation_expirations)
 
-                                    /**
-                                     * @brief Get an account's balances in various assets
-                                     * @param name of the account to get balances for
-                                     * @param assets names of the assets to get balances of; if empty, get all assets account has a balance in
-                                     * @return Balances of the account
-                                     */
+        ///////////////
+        // Witnesses //
+        ///////////////
 
+        /**
+         * @brief Get a list of witnesses by ID
+         * @param witness_ids IDs of the witnesses to retrieve
+         * @return The witnesses corresponding to the provided IDs
+         *
+         * This function has semantics identical to @ref get_objects
+         */
+        (get_witnesses)
 
-                                    /**
-                                     * @brief Get the total number of accounts registered with the blockchain
-                                     */
-                                    (get_account_count)
+        (get_conversion_requests)
 
-                                    (get_owner_history)
+        /**
+         * @brief Get the witness owned by a given account
+         * @param account The name of the account whose witness should be retrieved
+         * @return The witness object, or null if the account does not have a witness
+         */
+        (get_witness_by_account)
 
-                                    (get_recovery_request)
+        /**
+         *  This method is used to fetch witnesses with pagination.
+         *
+         *  @return an array of `count` witnesses sorted by total votes after witness `from` with at most `limit' results.
+         */
+        (get_witnesses_by_vote)
 
-                                    (get_escrow)
+        /**
+         * @brief Get names and IDs for registered witnesses
+         * @param lower_bound_name Lower bound of the first name to return
+         * @param limit Maximum number of results to return -- must not exceed 1000
+         * @return Map of witness names to corresponding IDs
+         */
+        (lookup_witness_accounts)
 
-                                    (get_withdraw_routes)
+        /**
+         * @brief Get the total number of witnesses registered with the blockchain
+         */
+        (get_witness_count)
 
-                                    (get_account_bandwidth)
+        ////////////
+        // Assets //
+        ////////////
 
-                                    (get_savings_withdraw_from)
 
-                                    (get_savings_withdraw_to)
 
-                                    (get_vesting_delegations)
-                                    (get_expiring_vesting_delegations)
-                                    // (list_vesting_delegations)
-                                    // (find_vesting_delegations)
-                                    // (list_vesting_delegation_expirations)
-                                    // (find_vesting_delegation_expirations)
 
-                                    ///////////////
-                                    // Witnesses //
-                                    ///////////////
+        ////////////////////////////
+        // Authority / Validation //
+        ////////////////////////////
 
-                                    /**
-                                     * @brief Get a list of witnesses by ID
-                                     * @param witness_ids IDs of the witnesses to retrieve
-                                     * @return The witnesses corresponding to the provided IDs
-                                     *
-                                     * This function has semantics identical to @ref get_objects
-                                     */
-                                    (get_witnesses)
+        /// @brief Get a hexdump of the serialized binary form of a transaction
+        (get_transaction_hex)
 
-                                    (get_conversion_requests)
+        /**
+         *  This API will take a partially signed transaction and a set of public keys that the owner has the ability to sign for
+         *  and return the minimal subset of public keys that should add signatures to the transaction.
+         */
+        (get_required_signatures)
 
-                                    /**
-                                     * @brief Get the witness owned by a given account
-                                     * @param account The name of the account whose witness should be retrieved
-                                     * @return The witness object, or null if the account does not have a witness
-                                     */
-                                    (get_witness_by_account)
+        /**
+         *  This method will return the set of all public keys that could possibly sign for a given transaction.  This call can
+         *  be used by wallets to filter their set of public keys to just the relevant subset prior to calling @ref get_required_signatures
+         *  to get the minimum subset.
+         */
+        (get_potential_signatures)
 
-                                    /**
-                                     *  This method is used to fetch witnesses with pagination.
-                                     *
-                                     *  @return an array of `count` witnesses sorted by total votes after witness `from` with at most `limit' results.
-                                     */
-                                    (get_witnesses_by_vote)
+        /**
+         * @return true of the @ref trx has all of the required signatures, otherwise throws an exception
+         */
+        (verify_authority)
 
-                                    /**
-                                     * @brief Get names and IDs for registered witnesses
-                                     * @param lower_bound_name Lower bound of the first name to return
-                                     * @param limit Maximum number of results to return -- must not exceed 1000
-                                     * @return Map of witness names to corresponding IDs
-                                     */
-                                    (lookup_witness_accounts)
+        /*
+        * @return true if the signers have enough authority to authorize an account
+        */
+        (verify_account_authority)
 
-                                    /**
-                                     * @brief Get the total number of witnesses registered with the blockchain
-                                     */
-                                    (get_witness_count)
 
-                                    ////////////
-                                    // Assets //
-                                    ////////////
+        (get_database_info)
 
+        (get_proposed_transactions)
+    )
 
+private:
+    struct api_impl;
+    std::shared_ptr<api_impl> my;
+};
 
+inline void register_database_api(){
+    appbase::app().register_plugin<plugin>();
+}
 
-                                    ////////////////////////////
-                                    // Authority / Validation //
-                                    ////////////////////////////
-
-                                    /// @brief Get a hexdump of the serialized binary form of a transaction
-                                    (get_transaction_hex)
-
-                                    /**
-                                     *  This API will take a partially signed transaction and a set of public keys that the owner has the ability to sign for
-                                     *  and return the minimal subset of public keys that should add signatures to the transaction.
-                                     */
-                                    (get_required_signatures)
-
-                                    /**
-                                     *  This method will return the set of all public keys that could possibly sign for a given transaction.  This call can
-                                     *  be used by wallets to filter their set of public keys to just the relevant subset prior to calling @ref get_required_signatures
-                                     *  to get the minimum subset.
-                                     */
-                                    (get_potential_signatures)
-
-                                    /**
-                                     * @return true of the @ref trx has all of the required signatures, otherwise throws an exception
-                                     */
-                                    (verify_authority)
-
-                                    /*
-                                     * @return true if the signers have enough authority to authorize an account
-                                     */
-                                    (verify_account_authority)
-
-
-                                    (get_database_info)
-
-                                    (get_proposed_transactions)
-                )
-
-            private:
-                struct api_impl;
-                std::shared_ptr<api_impl> my;
-            };
-
-
-            inline void register_database_api(){
-                appbase::app().register_plugin<plugin>();
-            }
 } } } // golos::plugins::database_api
-
 
 
 FC_REFLECT((golos::plugins::database_api::scheduled_hardfork), (hf_version)(live_time))

--- a/plugins/database_api/include/golos/plugins/database_api/plugin.hpp
+++ b/plugins/database_api/include/golos/plugins/database_api/plugin.hpp
@@ -58,6 +58,10 @@ namespace golos { namespace plugins { namespace database_api {
                 incoming, outgoing, all
             };
 
+            enum delegations_type {
+                delegated, received
+            };
+
 
             struct tag_count_object {
                 string tag;
@@ -224,7 +228,6 @@ namespace golos { namespace plugins { namespace database_api {
                                      */
                                     (get_block)
 
-                                    
                                     /**
                                      * @brief Set callback which is triggered on each generated block
                                      * @param callback function which should be called
@@ -416,14 +419,11 @@ namespace golos { namespace plugins { namespace database_api {
 
 
 
-
-
-
-
 FC_REFLECT((golos::plugins::database_api::scheduled_hardfork), (hf_version)(live_time))
 FC_REFLECT((golos::plugins::database_api::withdraw_route), (from_account)(to_account)(percent)(auto_vest))
 
 FC_REFLECT_ENUM(golos::plugins::database_api::withdraw_route_type, (incoming)(outgoing)(all))
+FC_REFLECT_ENUM(golos::plugins::database_api::delegations_type, (delegated)(received))
 
 FC_REFLECT((golos::plugins::database_api::tag_count_object), (tag)(count))
 


### PR DESCRIPTION
Added 4th argument (optional) to API method `get_vesting_delegations`. It can be either `delegated` (default) or `received`.

Actual changes are in the 1st commit.
2nd commit contains formatting only (un-indent to conform code style).

Closes #592.