### PR TITLE
Ability to create nesting proposals with cli_wallet #641

### DIFF
--- a/libraries/wallet/include/golos/wallet/wallet.hpp
+++ b/libraries/wallet/include/golos/wallet/wallet.hpp
@@ -139,6 +139,13 @@ namespace golos { namespace wallet {
             /**
              * @ingroup Transaction Builder API
              */
+            void add_operation_copy_to_builder_transaction(
+                transaction_handle_type src_handle, transaction_handle_type dst_handle, uint32_t op_index
+            );
+
+            /**
+             * @ingroup Transaction Builder API
+             */
             void replace_operation_in_builder_transaction(
                 transaction_handle_type handle, unsigned op_index, const operation& op
             );
@@ -1154,6 +1161,7 @@ FC_API( golos::wallet::wallet_api,
                 /// helper api
                 (begin_builder_transaction)
                 (add_operation_to_builder_transaction)
+                (add_operation_copy_to_builder_transaction)
                 (replace_operation_in_builder_transaction)
                 (preview_builder_transaction)
                 (sign_builder_transaction)

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -375,6 +375,19 @@ namespace golos { namespace wallet {
                     _builder_transactions[handle].operations.emplace_back(op);
                 }
 
+                void add_operation_copy_to_builder_transaction(
+                    transaction_handle_type src_handle,
+                    transaction_handle_type dst_handle,
+                    uint32_t op_index
+                ) {
+                    FC_ASSERT(_builder_transactions.count(src_handle));
+                    FC_ASSERT(_builder_transactions.count(dst_handle));
+                    signed_transaction& trx = _builder_transactions[src_handle];
+                    FC_ASSERT(op_index < trx.operations.size());
+                    const auto op = trx.operations[op_index];
+                    _builder_transactions[dst_handle].operations.emplace_back(op);
+                }
+
                 void replace_operation_in_builder_transaction(
                     transaction_handle_type handle,
                     uint32_t op_index,
@@ -393,7 +406,6 @@ namespace golos { namespace wallet {
 
                 signed_transaction sign_builder_transaction(transaction_handle_type handle, bool broadcast) {
                     FC_ASSERT(_builder_transactions.count(handle));
-
                     return _builder_transactions[handle] = sign_transaction(_builder_transactions[handle], broadcast);
                 }
 
@@ -1234,6 +1246,13 @@ fc::ecc::private_key wallet_api::derive_private_key(const std::string& prefix_st
 
         void wallet_api::add_operation_to_builder_transaction(transaction_handle_type handle, const operation& op) {
             my->add_operation_to_builder_transaction(handle, op);
+        }
+        void wallet_api::add_operation_copy_to_builder_transaction(
+            transaction_handle_type src_handle,
+            transaction_handle_type dst_handle,
+            uint32_t op_index
+        ) {
+            my->add_operation_copy_to_builder_transaction(src_handle, dst_handle, op_index);
         }
 
         void wallet_api::replace_operation_in_builder_transaction(

--- a/plugins/account_history/include/golos/plugins/account_history/plugin.hpp
+++ b/plugins/account_history/include/golos/plugins/account_history/plugin.hpp
@@ -101,7 +101,7 @@ public:
          *  @return sequence of operations included/generated within the block
          */
         (get_ops_in_block)
-        
+
         (get_transaction)
 
     )


### PR DESCRIPTION
`add_operation_copy_to_builder_transaction` command added to `cli_wallet`. The command accepts 3 arguments: `src_handle`, `dst_handle`, `op_index` and copies operation at `op_index` of `src_handle` transaction_builder to `dst_handle` transaction_builder.

Now the following is possible:
1. create parent builder_transaction (id=0) and put initial ops to it:
```
begin_builder_transaction
add_operation_to_builder_transaction 0 ["transfer", {"from":"bob", "to":"alice", "amount":"100.000 GOLOS", "memo":"from bob"}]
add_operation_to_builder_transaction 0 ["transfer", {"from":"cat", "to":"alice", "amount":"100.000 GOLOS", "memo":"from cat"}]
add_operation_to_builder_transaction 0 ["transfer", {"from":"dog", "to":"alice", "amount":"100.000 GOLOS", "memo":"from dog"}]
```
2. create child builder_transaction (id=1):
```
begin_builder_transaction
add_operation_to_builder_transaction 1 ["transfer", {"from":"alice", "to":"cat", "amount":"150.000 GOLOS", "memo":"prize"}]
add_operation_to_builder_transaction 1 ["transfer", {"from":"alice", "to":"dog", "amount":"150.000 GOLOS", "memo":"prize"}]
add_operation_to_builder_transaction 1 ["transfer", {"from":"cat", "to":"alice", "amount":"1.000 GOLOS", "memo":"reward"}]
add_operation_to_builder_transaction 1 ["transfer", {"from":"dog", "to":"alice", "amount":"1.000 GOLOS", "memo":"reward"}]
propose_builder_transaction 1 bob case1 "" "2018-05-11T14:00:00" "1970-01-01T00:00:00" false
```
3. repeat step 2 with different pairs to create case2 and case3 proposals
4. Using `add_operation_copy_to_builder_transaction` command put proposals, created on steps 2, 3 inside parent proposal:
```
add_operation_copy_to_builder_transaction 1 0 0
add_operation_copy_to_builder_transaction 2 0 0
add_operation_copy_to_builder_transaction 3 0 0
propose_builder_transaction 0 alice game "memo..." "2018-05-11T13:00:00" "2018-05-11T12:50:00" true
```