### PR TITLE
Fetch witness.url in cli_wallet update_witness command only if needed #713

### DIFF
--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -1864,18 +1864,14 @@ fc::ecc::private_key wallet_api::derive_private_key(const std::string& prefix_st
             signed_transaction tx;
             witness_update_operation op;
 
-            auto wit = my->_remote_witness_api->get_witness_by_account(witness_account_name);
-            if (!wit.valid()) {
-                op.url = url;
-            } else {
-                FC_ASSERT(wit->owner == witness_account_name);
-                if (!url.empty()) {
-                    op.url = url;
-                } else {
-                    op.url = wit->url;
+            if (url.empty()) {
+                auto wit = my->_remote_witness_api->get_witness_by_account(witness_account_name);
+                if (wit.valid()) {
+                    FC_ASSERT(wit->owner == witness_account_name);
+                    url = wit->url;
                 }
             }
-
+            op.url = url;
             op.owner = witness_account_name;
             op.block_signing_key = block_signing_key;
 


### PR DESCRIPTION
When use `update_witness` command, `cli_wallet` fetches `get_witness_by_account`. It's needed to preserve previous `url` value if `null` passed to command. But `get_witness_by_account` fetched either if `url` value is not `null`. (+ `get_witness_by_account` api method requires witness api plugin to be enabled on node)

This PR changes `update_witness` logic so it fetches `get_witness_by_account` only if `url` = `null`.

Closes #713