### PR TITLE
Simplify delegation parameters + related fixes

### DIFF
--- a/libraries/api/chain_api_properties.cpp
+++ b/libraries/api/chain_api_properties.cpp
@@ -10,10 +10,10 @@ namespace golos { namespace api {
         sbd_interest_rate(src.sbd_interest_rate)
     {
         if (db.has_hardfork(STEEMIT_HARDFORK_0_18__673)) {
-            create_account_with_golos_modifier = src.create_account_with_golos_modifier;
-            create_account_delegation_ratio = src.create_account_delegation_ratio;
+            create_account_min_golos_fee = src.create_account_min_golos_fee;
+            create_account_min_delegation = src.create_account_min_delegation;
             create_account_delegation_time = src.create_account_delegation_time;
-            min_delegation_multiplier = src.min_delegation_multiplier;
+            min_delegation = src.min_delegation;
         }
     }
 

--- a/libraries/api/include/golos/api/chain_api_properties.hpp
+++ b/libraries/api/include/golos/api/chain_api_properties.hpp
@@ -26,6 +26,6 @@ namespace golos { namespace api {
 
 FC_REFLECT(
     (golos::api::chain_api_properties),
-    (account_creation_fee)(maximum_block_size)(maximum_block_size)
+    (account_creation_fee)(maximum_block_size)(sbd_interest_rate)
     (create_account_min_golos_fee)(create_account_min_delegation)
     (create_account_delegation_time)(min_delegation))

--- a/libraries/api/include/golos/api/chain_api_properties.hpp
+++ b/libraries/api/include/golos/api/chain_api_properties.hpp
@@ -16,10 +16,10 @@ namespace golos { namespace api {
         uint32_t maximum_block_size;
         uint16_t sbd_interest_rate;
 
-        fc::optional<uint32_t> create_account_with_golos_modifier;
-        fc::optional<uint32_t> create_account_delegation_ratio;
-        fc::optional<fc::microseconds> create_account_delegation_time;
-        fc::optional<uint32_t> min_delegation_multiplier;
+        fc::optional<asset> create_account_min_golos_fee;
+        fc::optional<asset> create_account_min_delegation;
+        fc::optional<uint32_t> create_account_delegation_time;
+        fc::optional<asset> min_delegation;
     };
 
 } } // golos::api
@@ -27,5 +27,5 @@ namespace golos { namespace api {
 FC_REFLECT(
     (golos::api::chain_api_properties),
     (account_creation_fee)(maximum_block_size)(maximum_block_size)
-    (create_account_with_golos_modifier)(create_account_delegation_ratio)
-    (create_account_delegation_time)(min_delegation_multiplier))
+    (create_account_min_golos_fee)(create_account_min_delegation)
+    (create_account_delegation_time)(min_delegation))

--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -1671,10 +1671,10 @@ namespace golos { namespace chain {
             calc_median(&chain_properties_17::account_creation_fee);
             calc_median(&chain_properties_17::maximum_block_size);
             calc_median(&chain_properties_17::sbd_interest_rate);
-            calc_median(&chain_properties_18::create_account_with_golos_modifier);
-            calc_median(&chain_properties_18::create_account_delegation_ratio);
+            calc_median(&chain_properties_18::create_account_min_golos_fee);
+            calc_median(&chain_properties_18::create_account_min_delegation);
             calc_median(&chain_properties_18::create_account_delegation_time);
-            calc_median(&chain_properties_18::min_delegation_multiplier);
+            calc_median(&chain_properties_18::min_delegation);
 
             modify(wso, [&](witness_schedule_object &_wso) {
                 _wso.median_props = median_props;

--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -184,7 +184,12 @@ namespace golos { namespace chain {
             const auto& median_props = _db.get_witness_schedule_object().median_props;
             const auto target = median_props.create_account_min_golos_fee + median_props.create_account_min_delegation;
             auto target_delegation = target * v_share_price;
-            auto current_delegation = o.fee * target.amount.value / median_props.account_creation_fee.amount.value * v_share_price + o.delegation;
+            auto min_fee = median_props.account_creation_fee.amount.value;
+#ifdef STEEMIT_BUILD_TESTNET
+            if (!min_fee)
+                min_fee = 1;
+#endif
+            auto current_delegation = o.fee * target.amount.value / min_fee * v_share_price + o.delegation;
 
             FC_ASSERT(current_delegation >= target_delegation,
                 "Inssufficient Delegation ${f} required, ${p} provided.",

--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -108,20 +108,14 @@ namespace golos { namespace chain {
         }
 
         void account_create_evaluator::do_apply(const account_create_operation &o) {
-            database &_db = db();
-            const auto &creator = _db.get_account(o.creator);
+            const auto& creator = _db.get_account(o.creator);
 
-            const auto &props = _db.get_dynamic_global_properties();
-            const auto& median_props = _db.get_witness_schedule_object().median_props;
-
-            FC_ASSERT(creator.balance >=
-                      o.fee, "Insufficient balance to create account.", ("creator.balance", creator.balance)("required", o.fee));
+            FC_ASSERT(creator.balance >= o.fee,
+                "Insufficient balance to create account.", ("creator.balance", creator.balance)("required", o.fee));
 
             if (_db.has_hardfork(STEEMIT_HARDFORK_0_1)) {
-                auto min_fee = _db.get_witness_schedule_object().median_props.account_creation_fee;
-                if (_db.has_hardfork(STEEMIT_HARDFORK_0_18__535)) {
-                    min_fee *= median_props.create_account_with_golos_modifier;
-                }
+                const auto& median_props = _db.get_witness_schedule_object().median_props;
+                auto min_fee = median_props.account_creation_fee;
                 FC_ASSERT(o.fee >= min_fee,
                     "Insufficient Fee: ${f} required, ${p} provided.", ("f", min_fee)("p", o.fee));
             }
@@ -145,6 +139,7 @@ namespace golos { namespace chain {
                 c.balance -= o.fee;
             });
 
+            const auto& props = _db.get_dynamic_global_properties();
             const auto& new_account = _db.create<account_object>([&](account_object& acc) {
                 acc.name = o.new_account_name;
                 acc.memo_key = o.memo_key;
@@ -187,18 +182,15 @@ namespace golos { namespace chain {
 
             const auto& v_share_price = _db.get_dynamic_global_properties().get_vesting_share_price();
             const auto& median_props = _db.get_witness_schedule_object().median_props;
-            auto target_delegation =
-                median_props.create_account_delegation_ratio *
-                median_props.create_account_with_golos_modifier *
-                median_props.account_creation_fee * v_share_price;
-            auto current_delegation =
-                median_props.create_account_delegation_ratio * o.fee * v_share_price + o.delegation;
+            const auto target = median_props.create_account_min_golos_fee + median_props.create_account_min_delegation;
+            auto target_delegation = target * v_share_price;
+            auto current_delegation = o.fee * target.amount.value / median_props.account_creation_fee.amount.value * v_share_price + o.delegation;
 
             FC_ASSERT(current_delegation >= target_delegation,
                 "Inssufficient Delegation ${f} required, ${p} provided.",
                 ("f", target_delegation)("p", current_delegation)("o.fee", o.fee) ("o.delegation", o.delegation));
-            FC_ASSERT(o.fee >= median_props.account_creation_fee,
-                "Insufficient Fee: ${f} required, ${p} provided.", ("f", median_props.account_creation_fee)("p", o.fee));
+            FC_ASSERT(o.fee >= median_props.create_account_min_golos_fee,
+                "Insufficient Fee: ${f} required, ${p} provided.", ("f", median_props.create_account_min_golos_fee)("p", o.fee));
 
             for (auto& a : o.owner.account_auths) {
                 _db.get_account(a.first);
@@ -239,7 +231,7 @@ namespace golos { namespace chain {
                     d.delegator = o.creator;
                     d.delegatee = o.new_account_name;
                     d.vesting_shares = o.delegation;
-                    d.min_delegation_time = now + median_props.create_account_delegation_time;
+                    d.min_delegation_time = now + fc::seconds(median_props.create_account_delegation_time);
                 });
             }
             if (o.fee.amount > 0) {
@@ -2200,8 +2192,8 @@ namespace golos { namespace chain {
 
             const auto& median_props = _db.get_witness_schedule_object().median_props;
             const auto v_share_price = _db.get_dynamic_global_properties().get_vesting_share_price();
-            auto min_delegation = median_props.account_creation_fee * median_props.min_delegation_multiplier * v_share_price;
-            auto min_update = median_props.account_creation_fee * v_share_price;
+            auto min_delegation = median_props.min_delegation * v_share_price;
+            auto min_update = median_props.create_account_min_golos_fee * v_share_price;
 
             auto now = _db.head_block_time();
             auto delta = delegation ?

--- a/libraries/wallet/include/golos/wallet/wallet.hpp
+++ b/libraries/wallet/include/golos/wallet/wallet.hpp
@@ -32,6 +32,17 @@ namespace golos { namespace wallet {
             vector<string> key_approvals_to_remove;
         };
 
+        struct optional_chain_props {
+            fc::optional<asset> account_creation_fee;
+            fc::optional<uint32_t> maximum_block_size;
+            fc::optional<uint16_t> sbd_interest_rate;
+
+            fc::optional<asset> create_account_min_golos_fee;
+            fc::optional<asset> create_account_min_delegation;
+            fc::optional<uint32_t> create_account_delegation_time;
+            fc::optional<asset> min_delegation;
+        };
+
         struct memo_data {
 
             static optional<memo_data> from_string( string str ) {
@@ -678,7 +689,7 @@ namespace golos { namespace wallet {
              */
             annotated_signed_transaction update_chain_properties(
                 string witness_name,
-                const chain_properties& props,
+                const optional_chain_props& props,
                 bool broadcast = false
             );
 
@@ -1203,10 +1214,15 @@ FC_API( golos::wallet::wallet_api,
                 (get_outbox)
 )
 
-FC_REFLECT( (golos::wallet::memo_data), (from)(to)(nonce)(check)(encrypted) )
+FC_REFLECT((golos::wallet::memo_data), (from)(to)(nonce)(check)(encrypted))
 FC_REFLECT(
     (golos::wallet::approval_delta),
     (active_approvals_to_add)(active_approvals_to_remove)
     (owner_approvals_to_add)(owner_approvals_to_remove)
     (posting_approvals_to_add)(posting_approvals_to_remove)
-    (key_approvals_to_add)(key_approvals_to_remove) )
+    (key_approvals_to_add)(key_approvals_to_remove))
+
+FC_REFLECT((golos::wallet::optional_chain_props),
+    (account_creation_fee)(maximum_block_size)(sbd_interest_rate)
+    (create_account_min_golos_fee)(create_account_min_delegation)
+    (create_account_delegation_time)(min_delegation))

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -1901,6 +1901,12 @@ fc::ecc::private_key wallet_api::derive_private_key(const std::string& prefix_st
             chain_properties_update_operation op;
             chain_api_properties ap;
             chain_properties p;
+
+            // copy defaults in case of missing witness object
+            ap.account_creation_fee = p.account_creation_fee;
+            ap.maximum_block_size = p.maximum_block_size;
+            ap.sbd_interest_rate = p.sbd_interest_rate;
+
             auto wit = my->_remote_witness_api->get_witness_by_account(witness_account_name);
             if (wit.valid()) {
                 FC_ASSERT(wit->owner == witness_account_name);

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -290,10 +290,10 @@ namespace golos { namespace wallet {
 
                     auto hf = _remote_database_api->get_hardfork_version();
                     if (hf >= hardfork_version(0, STEEMIT_HARDFORK_0_18)) {
-                        result["create_account_with_golos_modifier"] = median_props.create_account_with_golos_modifier;
-                        result["create_account_delegation_ratio"] = median_props.create_account_delegation_ratio;
+                        result["create_account_min_golos_fee"] = median_props.create_account_min_golos_fee;
+                        result["create_account_min_delegation"] = median_props.create_account_min_delegation;
                         result["create_account_delegation_time"] = median_props.create_account_delegation_time;
-                        result["min_delegation_multiplier"] = median_props.min_delegation_multiplier;
+                        result["min_delegation"] = median_props.min_delegation;
                     }
 
                     return result;
@@ -1834,9 +1834,6 @@ fc::ecc::private_key wallet_api::derive_private_key(const std::string& prefix_st
                     auto prop = my->_remote_database_api->get_chain_properties();
                     auto hf = my->_remote_database_api->get_hardfork_version();
                     fee = prop.account_creation_fee;
-                    if (hf >= hardfork_version(0, STEEMIT_HARDFORK_0_18)) {
-                        fee *= prop.create_account_with_golos_modifier;
-                    }
                 }
                 return create_account_with_keys(
                     creator, new_account_name, json_meta, fee,

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -6287,7 +6287,6 @@ BOOST_FIXTURE_TEST_SUITE(operation_tests, clean_database_fixture)
             signed_transaction tx;
             ACTOR(alice);
 
-            // 150 * fee = (5 * GOLOS) + GP
             generate_blocks(1);
             fund("alice", ASSET_GOLOS(10));
             vest("alice", ASSET_GOLOS(10000));
@@ -6346,9 +6345,9 @@ BOOST_FIXTURE_TEST_SUITE(operation_tests, clean_database_fixture)
 
             BOOST_TEST_MESSAGE("--- Test success using only GOLOS to reach target delegation");
             const auto& gp = db->get_dynamic_global_properties();
-            const auto fee_mult = GOLOS_CREATE_ACCOUNT_WITH_GOLOS_MODIFIER * GOLOS_CREATE_ACCOUNT_DELEGATION_RATIO;
-            auto min_fee = db->get_witness_schedule_object().median_props.account_creation_fee;
-            auto required_fee = fee_mult * min_fee;
+            const auto& mp = db->get_witness_schedule_object().median_props;
+            auto min_fee = mp.create_account_min_golos_fee;
+            auto required_fee = min_fee + mp.create_account_min_delegation;
             auto required_gests = required_fee * gp.get_vesting_share_price();
             op.fee = required_fee;
             op.delegation = ASSET_GESTS(0);


### PR DESCRIPTION
1. Remove delegation multipliers and use absolute values. (Closes #726).
Parameters:

param|description
-|-
`account_creation_fee` | Now it's used only in `create_account operation` (as in previous HF)
`create_account_min_golos_fee` | When use `account_create_with_delegation` it's minimal fee (in GOLOS) creator should pay (+ he delegates `create_account_min_delegation` amount)
`create_account_min_delegation` | When use `account_create_with_delegation` it's GP minimal delegation amount creator delegate to new account (can be reduced if `fee` > `create_account_min_golos_fee`)
`min_delegation` | When anybody delegates, it's minimal delegated GP can be sent to delegatee

2. `create_account_delegation_time` now accepts seconds (was microseconds).

3. Fixes #724 validation and improves `update_chain_properties` to reuse previous values
4. Fixes #727
