### PR TITLE
cli_wallet list_keys - Added accounts and key types, and filter by account #722

### DIFF
--- a/libraries/wallet/include/golos/wallet/wallet.hpp
+++ b/libraries/wallet/include/golos/wallet/wallet.hpp
@@ -352,13 +352,13 @@ namespace golos { namespace wallet {
              */
             void    set_password(string password);
 
-            /** Dumps all private keys owned by the wallet.
+            /** Dumps private keys from all accounts owned by the wallet or from the specific account.
              *
              * The keys are printed in WIF format. You can import these keys into another wallet
              * using \c import_key()
-             * @returns a map containing the private keys, indexed by their public key
+             * @returns a vector of vectors containing the private keys, public keys, account names, key types
              */
-            map<public_key_type, string> list_keys();
+            vector<vector<string>> list_keys(string account);
 
             /** Returns detailed help on a single API command.
              * @param method the name of the API command you want help with

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -1343,10 +1343,59 @@ fc::ecc::private_key wallet_api::derive_private_key(const std::string& prefix_st
             lock();
         }
 
-        map<public_key_type, string> wallet_api::list_keys()
+        vector<vector<string>> wallet_api::list_keys(string account)
         {
             FC_ASSERT(!is_locked());
-            return my->_keys;
+
+            vector<vector<string>> all_keys;
+
+            vector<golos::api::account_api_object> accounts;
+            if (account.empty()) {
+                accounts = list_my_accounts();
+            } else {
+                accounts.push_back(get_account(account));
+            }
+            
+            for (auto it = accounts.begin(); it != accounts.end(); it++) {
+                vector<string> memo_key_data;
+                memo_key_data.push_back(std::string(it->memo_key));
+                memo_key_data.push_back(get_private_key(it->memo_key));
+                memo_key_data.push_back(std::string(it->name));
+                memo_key_data.push_back("memo_key");
+                all_keys.push_back(memo_key_data);
+
+                auto acc_owner_keys = it->owner.get_keys();
+                for (auto it2 = acc_owner_keys.begin(); it2 != acc_owner_keys.end(); it2++) { 
+                    vector<string> key_data;
+                    key_data.push_back(std::string(*it2));
+                    key_data.push_back(get_private_key(*it2));
+                    key_data.push_back(std::string(it->name));
+                    key_data.push_back("owner");
+                    all_keys.push_back(key_data);
+                }
+
+                auto acc_active_keys = it->active.get_keys();
+                for (auto it2 = acc_active_keys.begin(); it2 != acc_active_keys.end(); it2++) { 
+                    vector<string> key_data;
+                    key_data.push_back(std::string(*it2));
+                    key_data.push_back(get_private_key(*it2));
+                    key_data.push_back(std::string(it->name));
+                    key_data.push_back("active");
+                    all_keys.push_back(key_data);
+                }
+
+                auto acc_posting_keys = it->posting.get_keys();
+                for (auto it2 = acc_posting_keys.begin(); it2 != acc_posting_keys.end(); it2++) { 
+                    vector<string> key_data;
+                    key_data.push_back(std::string(*it2));
+                    key_data.push_back(get_private_key(*it2));
+                    key_data.push_back(std::string(it->name));
+                    key_data.push_back("posting");
+                    all_keys.push_back(key_data);
+                }
+            }
+
+            return all_keys;
         }
 
         string wallet_api::get_private_key( public_key_type pubkey )const


### PR DESCRIPTION
In past list_keys() was just returning all keys map, now it uses list_my_accounts (or get_account if filtering by account is specified) to get user's account(-s), and prints each key of each account + account name + key type.