### PR TITLE
Add config flag to store/not account metadata in db, mongo #794

### DIFF
--- a/libraries/api/account_api_object.cpp
+++ b/libraries/api/account_api_object.cpp
@@ -45,8 +45,11 @@ account_api_object::account_api_object(const account_object& a, const golos::cha
     last_owner_update = auth.last_owner_update;
 
     if (db.store_account_metadata()) {
-        const auto& meta = db.get<account_metadata_object, by_account>(name);
-        json_metadata = golos::chain::to_string(meta.json_metadata);
+        try {
+            const auto& meta = db.get<account_metadata_object, by_account>(name);
+            json_metadata = golos::chain::to_string(meta.json_metadata);
+        } catch (...) {
+        }
     }
 
     auto post = db.find<account_bandwidth_object, by_account_bandwidth_type>(std::make_tuple(name, bandwidth_type::post));

--- a/libraries/api/account_api_object.cpp
+++ b/libraries/api/account_api_object.cpp
@@ -44,10 +44,10 @@ account_api_object::account_api_object(const account_object& a, const golos::cha
     posting = authority(auth.posting);
     last_owner_update = auth.last_owner_update;
 
-#ifndef IS_LOW_MEM
-    const auto& meta = db.get<account_metadata_object, by_account>(name);
-    json_metadata = golos::chain::to_string(meta.json_metadata);
-#endif
+    if (db.store_account_metadata()) {
+        const auto& meta = db.get<account_metadata_object, by_account>(name);
+        json_metadata = golos::chain::to_string(meta.json_metadata);
+    }
 
     auto post = db.find<account_bandwidth_object, by_account_bandwidth_type>(std::make_tuple(name, bandwidth_type::post));
     if (post != nullptr) {

--- a/libraries/api/account_api_object.cpp
+++ b/libraries/api/account_api_object.cpp
@@ -45,10 +45,9 @@ account_api_object::account_api_object(const account_object& a, const golos::cha
     last_owner_update = auth.last_owner_update;
 
     if (db.store_account_metadata()) {
-        try {
-            const auto& meta = db.get<account_metadata_object, by_account>(name);
-            json_metadata = golos::chain::to_string(meta.json_metadata);
-        } catch (...) {
+        auto meta = db.find<account_metadata_object, by_account>(name);
+        if (meta != nullptr) {
+            json_metadata = golos::chain::to_string(meta->json_metadata);
         }
     }
 

--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -352,6 +352,14 @@ namespace golos { namespace chain {
             return _clear_votes_block > head_block_num();
         }
 
+        void database::set_store_account_metadata(bool store_account_metadata) {
+            _store_account_metadata = store_account_metadata;
+        }
+
+        bool database::store_account_metadata() const {
+            return _store_account_metadata;
+        }
+
         void database::set_skip_virtual_ops() {
             _skip_virtual_ops = true;
         }
@@ -3011,11 +3019,13 @@ namespace golos { namespace chain {
                 create<account_object>([&](account_object &a) {
                     a.name = STEEMIT_MINER_ACCOUNT;
                 });
-#ifndef IS_LOW_MEM
-                create<account_metadata_object>([&](account_metadata_object& m) {
-                    m.account = STEEMIT_MINER_ACCOUNT;
-                });
-#endif
+
+                if (store_account_metadata()) {
+                    create<account_metadata_object>([&](account_metadata_object& m) {
+                        m.account = STEEMIT_MINER_ACCOUNT;
+                    });
+                }
+
                 create<account_authority_object>([&](account_authority_object &auth) {
                     auth.account = STEEMIT_MINER_ACCOUNT;
                     auth.owner.weight_threshold = 1;
@@ -3025,11 +3035,13 @@ namespace golos { namespace chain {
                 create<account_object>([&](account_object &a) {
                     a.name = STEEMIT_NULL_ACCOUNT;
                 });
-#ifndef IS_LOW_MEM
-                create<account_metadata_object>([&](account_metadata_object& m) {
-                    m.account = STEEMIT_NULL_ACCOUNT;
-                });
-#endif
+                
+                if (store_account_metadata()) {
+                    create<account_metadata_object>([&](account_metadata_object& m) {
+                        m.account = STEEMIT_NULL_ACCOUNT;
+                    });
+                }
+                
                 create<account_authority_object>([&](account_authority_object &auth) {
                     auth.account = STEEMIT_NULL_ACCOUNT;
                     auth.owner.weight_threshold = 1;
@@ -3039,11 +3051,13 @@ namespace golos { namespace chain {
                 create<account_object>([&](account_object &a) {
                     a.name = STEEMIT_TEMP_ACCOUNT;
                 });
-#ifndef IS_LOW_MEM
-                create<account_metadata_object>([&](account_metadata_object& m) {
-                    m.account = STEEMIT_TEMP_ACCOUNT;
-                });
-#endif
+
+                if (store_account_metadata()) {
+                    create<account_metadata_object>([&](account_metadata_object& m) {
+                        m.account = STEEMIT_TEMP_ACCOUNT;
+                    });
+                }
+
                 create<account_authority_object>([&](account_authority_object &auth) {
                     auth.account = STEEMIT_TEMP_ACCOUNT;
                     auth.owner.weight_threshold = 0;
@@ -3057,11 +3071,13 @@ namespace golos { namespace chain {
                         a.memo_key = init_public_key;
                         a.balance = asset(i ? 0 : init_supply, STEEM_SYMBOL);
                     });
-#ifndef IS_LOW_MEM
-                    create<account_metadata_object>([&](account_metadata_object& m) {
-                        m.account = name;
-                    });
-#endif
+
+                    if (store_account_metadata()) {
+                        create<account_metadata_object>([&](account_metadata_object& m) {
+                            m.account = name;
+                        });
+                    }
+
                     create<account_authority_object>([&](account_authority_object &auth) {
                         auth.account = name;
                         auth.owner.add_authority(init_public_key, 1);
@@ -3120,12 +3136,14 @@ namespace golos { namespace chain {
                         a.memo_key = account.keys.memo_key;
                         a.recovery_account = STEEMIT_INIT_MINER_NAME;
                     });
-#ifndef IS_LOW_MEM
-                    create<account_metadata_object>([&](account_metadata_object& m) {
-                        m.account = account.name;
-                        m.json_metadata = "{created_at: 'GENESIS'}";
-                    });
-#endif
+
+                    if (store_account_metadata()) {
+                        create<account_metadata_object>([&](account_metadata_object& m) {
+                            m.account = account.name;
+                            m.json_metadata = "{created_at: 'GENESIS'}";
+                        });
+                    }
+                    
                     create<account_authority_object>([&](account_authority_object& auth) {
                         auth.account = account.name;
                         auth.owner.weight_threshold = 1;

--- a/libraries/chain/include/golos/chain/database.hpp
+++ b/libraries/chain/include/golos/chain/database.hpp
@@ -99,6 +99,8 @@ namespace golos { namespace chain {
             void set_clear_votes(uint32_t clear_votes_block);
             void set_skip_virtual_ops();
             bool clear_votes();
+            void set_store_account_metadata(bool store_account_metadata);
+            bool store_account_metadata() const;
 
             /**
              * @brief wipe Delete database from disk, and potentially the raw chain as well.
@@ -618,6 +620,7 @@ namespace golos { namespace chain {
             uint32_t _clear_votes_block = 0;
             bool _skip_virtual_ops = false;
             bool _enable_plugins_on_push_transaction = true;
+            bool _store_account_metadata = true;
 
             flat_map<std::string, std::shared_ptr<custom_operation_interpreter>> _custom_operation_interpreters;
             std::string _json_schema;

--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -87,7 +87,9 @@ namespace golos { namespace chain {
         void store_account_json_metadata(
             database& db, const account_name_type& account, const string& json_metadata, bool skip_empty = false
         ) {
-#ifndef IS_LOW_MEM
+            if (!db.store_account_metadata())
+                return;
+
             if (skip_empty && json_metadata.size() == 0)
                 return;
 
@@ -104,7 +106,6 @@ namespace golos { namespace chain {
                     from_string(a.json_metadata, json_metadata);
                 });
             }
-#endif
         }
 
         void account_create_evaluator::do_apply(const account_create_operation &o) {

--- a/plugins/chain/plugin.cpp
+++ b/plugins/chain/plugin.cpp
@@ -55,6 +55,8 @@ namespace chain {
 
         bool single_write_thread = false;
 
+        bool store_account_metadata = true;
+
         plugin_impl() {
             // get default settings
             read_wait_micro = db.read_wait_micro();
@@ -232,6 +234,9 @@ namespace chain {
             ) (
                 "replay-if-corrupted", boost::program_options::bool_switch()->default_value(true),
                 "replay all blocks if shared memory is corrupted"
+            ) (
+                "store-account-metadata", boost::program_options::bool_switch()->default_value(true),
+                "store account metadata in database"
             );
         cli.add_options()
             (
@@ -313,6 +318,8 @@ namespace chain {
                 my->loaded_checkpoints[item.first] = item.second;
             }
         }
+
+        my->store_account_metadata = options.at("store-account-metadata").as<bool>();
     }
 
     void plugin::plugin_startup() {
@@ -338,6 +345,8 @@ namespace chain {
         my->db.set_min_free_shared_memory_size(my->min_free_shared_memory_size);
 
         my->db.set_clear_votes(my->clear_votes_before_block);
+
+        my->db.set_store_account_metadata(my->store_account_metadata);
 
         if(my->skip_virtual_ops) {
             my->db.set_skip_virtual_ops();

--- a/plugins/mongo_db/mongo_db_state.cpp
+++ b/plugins/mongo_db/mongo_db_state.cpp
@@ -240,10 +240,9 @@ namespace mongo_db {
             format_value(body, "last_post", account.last_post);
 
             if (db_.store_account_metadata()) {
-                try {
-                    auto& account_metadata = db_.get<account_metadata_object, by_account>(account.name);
-                    format_value(body, "json_metadata", account_metadata.json_metadata);
-                } catch (...) {
+                auto account_metadata = db_.find<account_metadata_object, by_account>(account.name);
+                if (account_metadata != nullptr) {
+                    format_value(body, "json_metadata", account_metadata->json_metadata);
                 }
             }
 

--- a/plugins/mongo_db/mongo_db_state.cpp
+++ b/plugins/mongo_db/mongo_db_state.cpp
@@ -239,11 +239,11 @@ namespace mongo_db {
 
             format_value(body, "last_post", account.last_post);
 
-#ifndef IS_LOW_MEM
-            auto& account_metadata = db_.get<account_metadata_object, by_account>(account.name);
-            
-            format_value(body, "json_metadata", account_metadata.json_metadata);
-#endif
+            if (db_.store_account_metadata()) {
+                auto& account_metadata = db_.get<account_metadata_object, by_account>(account.name);
+                
+                format_value(body, "json_metadata", account_metadata.json_metadata);
+            }
 
             body << close_document;
 

--- a/plugins/mongo_db/mongo_db_state.cpp
+++ b/plugins/mongo_db/mongo_db_state.cpp
@@ -240,9 +240,11 @@ namespace mongo_db {
             format_value(body, "last_post", account.last_post);
 
             if (db_.store_account_metadata()) {
-                auto& account_metadata = db_.get<account_metadata_object, by_account>(account.name);
-                
-                format_value(body, "json_metadata", account_metadata.json_metadata);
+                try {
+                    auto& account_metadata = db_.get<account_metadata_object, by_account>(account.name);
+                    format_value(body, "json_metadata", account_metadata.json_metadata);
+                } catch (...) {
+                }
             }
 
             body << close_document;


### PR DESCRIPTION
https://github.com/GolosChain/golos/issues/794

Checklists:

**1. Add to config** 

store-account-metadata = false

Result: cyberfounder account in Mongo hasn't json_metadata field

**2. Change**

store-account-metadata = true

Result: cyberfounder account in Mongo has json_metadata field

**3. Remove store-account-metadata from config**

Result: cyberfounder account in Mongo has json_metadata field

**4. Checked if not mixed cfg with cli options**

Result: not mixed.

**5. Check account_api_object with true and with false**

```
./cli_wallet --server-rpc-endpoint=ws://127.0.0.1:8091
set_password qwer
unlock qwer
import_key 5JVFFWRLwz6JoP9kguuRFfytToGU6cLgBVTL9t6NB3D3BQLbUBS
create_account cyberfounder alice "{\"test\":123}" "300.000 GOLOS" true
get_account "alice"
```

Result: OK (and first one has correct json_metadata in Mongo) and OK.