### PR TITLE
Add to config list of accounts to store metadata in db, mongo #794

### DIFF
--- a/libraries/api/account_api_object.cpp
+++ b/libraries/api/account_api_object.cpp
@@ -44,10 +44,10 @@ account_api_object::account_api_object(const account_object& a, const golos::cha
     posting = authority(auth.posting);
     last_owner_update = auth.last_owner_update;
 
-#ifndef IS_LOW_MEM
-    const auto& meta = db.get<account_metadata_object, by_account>(name);
-    json_metadata = golos::chain::to_string(meta.json_metadata);
-#endif
+    auto meta = db.find<account_metadata_object, by_account>(name);
+    if (meta != nullptr) {
+        json_metadata = golos::chain::to_string(meta->json_metadata);
+    }
 
     auto post = db.find<account_bandwidth_object, by_account_bandwidth_type>(std::make_tuple(name, bandwidth_type::post));
     if (post != nullptr) {

--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -352,6 +352,22 @@ namespace golos { namespace chain {
             return _clear_votes_block > head_block_num();
         }
 
+        void database::set_store_account_metadata(store_metadata_modes store_account_metadata) {
+            _store_account_metadata = store_account_metadata;
+        }
+
+        void database::set_accounts_to_store_metadata(const std::vector<std::string>& accounts_to_store_metadata) {
+            _accounts_to_store_metadata = accounts_to_store_metadata;
+        }
+
+        bool database::store_metadata_for_account(const std::string& name) const {
+            if (_store_account_metadata != store_metadata_for_listed) {
+                return _store_account_metadata == store_metadata_for_all;
+            }
+            auto& v = _accounts_to_store_metadata;
+            return std::find(v.begin(), v.end(), name) != v.end();
+        }
+
         void database::set_skip_virtual_ops() {
             _skip_virtual_ops = true;
         }
@@ -3011,11 +3027,13 @@ namespace golos { namespace chain {
                 create<account_object>([&](account_object &a) {
                     a.name = STEEMIT_MINER_ACCOUNT;
                 });
-#ifndef IS_LOW_MEM
-                create<account_metadata_object>([&](account_metadata_object& m) {
-                    m.account = STEEMIT_MINER_ACCOUNT;
-                });
-#endif
+
+                if (store_metadata_for_account(STEEMIT_MINER_ACCOUNT)) {
+                    create<account_metadata_object>([&](account_metadata_object& m) {
+                        m.account = STEEMIT_MINER_ACCOUNT;
+                    });
+                }
+
                 create<account_authority_object>([&](account_authority_object &auth) {
                     auth.account = STEEMIT_MINER_ACCOUNT;
                     auth.owner.weight_threshold = 1;
@@ -3025,11 +3043,13 @@ namespace golos { namespace chain {
                 create<account_object>([&](account_object &a) {
                     a.name = STEEMIT_NULL_ACCOUNT;
                 });
-#ifndef IS_LOW_MEM
-                create<account_metadata_object>([&](account_metadata_object& m) {
-                    m.account = STEEMIT_NULL_ACCOUNT;
-                });
-#endif
+                
+                if (store_metadata_for_account(STEEMIT_NULL_ACCOUNT)) {
+                    create<account_metadata_object>([&](account_metadata_object& m) {
+                        m.account = STEEMIT_NULL_ACCOUNT;
+                    });
+                }
+                
                 create<account_authority_object>([&](account_authority_object &auth) {
                     auth.account = STEEMIT_NULL_ACCOUNT;
                     auth.owner.weight_threshold = 1;
@@ -3039,11 +3059,13 @@ namespace golos { namespace chain {
                 create<account_object>([&](account_object &a) {
                     a.name = STEEMIT_TEMP_ACCOUNT;
                 });
-#ifndef IS_LOW_MEM
-                create<account_metadata_object>([&](account_metadata_object& m) {
-                    m.account = STEEMIT_TEMP_ACCOUNT;
-                });
-#endif
+
+                if (store_metadata_for_account(STEEMIT_TEMP_ACCOUNT)) {
+                    create<account_metadata_object>([&](account_metadata_object& m) {
+                        m.account = STEEMIT_TEMP_ACCOUNT;
+                    });
+                }
+
                 create<account_authority_object>([&](account_authority_object &auth) {
                     auth.account = STEEMIT_TEMP_ACCOUNT;
                     auth.owner.weight_threshold = 0;
@@ -3057,11 +3079,13 @@ namespace golos { namespace chain {
                         a.memo_key = init_public_key;
                         a.balance = asset(i ? 0 : init_supply, STEEM_SYMBOL);
                     });
-#ifndef IS_LOW_MEM
-                    create<account_metadata_object>([&](account_metadata_object& m) {
-                        m.account = name;
-                    });
-#endif
+
+                    if (store_metadata_for_account(name)) {
+                        create<account_metadata_object>([&](account_metadata_object& m) {
+                            m.account = name;
+                        });
+                    }
+
                     create<account_authority_object>([&](account_authority_object &auth) {
                         auth.account = name;
                         auth.owner.add_authority(init_public_key, 1);
@@ -3120,12 +3144,14 @@ namespace golos { namespace chain {
                         a.memo_key = account.keys.memo_key;
                         a.recovery_account = STEEMIT_INIT_MINER_NAME;
                     });
-#ifndef IS_LOW_MEM
-                    create<account_metadata_object>([&](account_metadata_object& m) {
-                        m.account = account.name;
-                        m.json_metadata = "{created_at: 'GENESIS'}";
-                    });
-#endif
+
+                    if (store_metadata_for_account(account.name)) {
+                        create<account_metadata_object>([&](account_metadata_object& m) {
+                            m.account = account.name;
+                            m.json_metadata = "{created_at: 'GENESIS'}";
+                        });
+                    }
+                    
                     create<account_authority_object>([&](account_authority_object& auth) {
                         auth.account = account.name;
                         auth.owner.weight_threshold = 1;

--- a/libraries/chain/include/golos/chain/database.hpp
+++ b/libraries/chain/include/golos/chain/database.hpp
@@ -72,6 +72,12 @@ namespace golos { namespace chain {
                 skip_database_locking = 1 << 15 ///< used to skip locking of database
             };
 
+            enum store_metadata_modes {
+                store_metadata_for_all,
+                store_metadata_for_listed,
+                store_metadata_for_nobody
+            };
+
             /**
              * @brief Open a database, creating a new one if necessary
              *
@@ -99,6 +105,9 @@ namespace golos { namespace chain {
             void set_clear_votes(uint32_t clear_votes_block);
             void set_skip_virtual_ops();
             bool clear_votes();
+            void set_store_account_metadata(store_metadata_modes store_account_metadata);
+            void set_accounts_to_store_metadata(const std::vector<std::string>& accounts_to_store_metadata);
+            bool store_metadata_for_account(const std::string& name) const;
 
             /**
              * @brief wipe Delete database from disk, and potentially the raw chain as well.
@@ -618,6 +627,8 @@ namespace golos { namespace chain {
             uint32_t _clear_votes_block = 0;
             bool _skip_virtual_ops = false;
             bool _enable_plugins_on_push_transaction = true;
+            store_metadata_modes _store_account_metadata = store_metadata_for_all;
+            std::vector<std::string> _accounts_to_store_metadata;
 
             flat_map<std::string, std::shared_ptr<custom_operation_interpreter>> _custom_operation_interpreters;
             std::string _json_schema;

--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -87,7 +87,14 @@ namespace golos { namespace chain {
         void store_account_json_metadata(
             database& db, const account_name_type& account, const string& json_metadata, bool skip_empty = false
         ) {
-#ifndef IS_LOW_MEM
+            if (!db.store_metadata_for_account(account)) {
+                auto meta = db.find<account_metadata_object, by_account>(account);
+                if (meta != nullptr) {
+                    db.remove(*meta);
+                }
+                return;
+            }
+
             if (skip_empty && json_metadata.size() == 0)
                 return;
 
@@ -104,7 +111,6 @@ namespace golos { namespace chain {
                     from_string(a.json_metadata, json_metadata);
                 });
             }
-#endif
         }
 
         void account_create_evaluator::do_apply(const account_create_operation &o) {

--- a/plugins/mongo_db/mongo_db_state.cpp
+++ b/plugins/mongo_db/mongo_db_state.cpp
@@ -239,11 +239,10 @@ namespace mongo_db {
 
             format_value(body, "last_post", account.last_post);
 
-#ifndef IS_LOW_MEM
-            auto& account_metadata = db_.get<account_metadata_object, by_account>(account.name);
-            
-            format_value(body, "json_metadata", account_metadata.json_metadata);
-#endif
+            auto account_metadata = db_.find<account_metadata_object, by_account>(account.name);
+            if (account_metadata != nullptr) {
+                format_value(body, "json_metadata", account_metadata->json_metadata);
+            }
 
             body << close_document;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(
         golos_account_history
         golos_market_history
         golos_debug_node
+        golos::api
         fc ${PLATFORM_SPECIFIC_LIBS})
 
 add_test(NAME chain_test_run COMMAND chain_test)


### PR DESCRIPTION
https://github.com/GolosChain/golos/issues/794

**1. Check for default storing for all**

Do not add anything to config.

```
./cli_wallet --server-rpc-endpoint=ws://127.0.0.1:8091
set_password qwer
unlock qwer
import_key 5JVFFWRLwz6JoP9kguuRFfytToGU6cLgBVTL9t6NB3D3BQLbUBS
create_account cyberfounder alice "{\"test\":123}" "300.000 GOLOS" true
create_account cyberfounder bob "{\"test\":123}" "300.000 GOLOS" true
get_account "alice"
get_account "bob"

```

Results:
- No exceptions in cli_wallet
- Mongo has `json_metadata` for cyberfounder, bob, alice
- get_account result for bob and alice has specified `json_metadata

**1.1 Check for specified storing for all**

Add to config: 
store-account-metadata = true

Do same test.

Results: same

**2. Check for restricted storing**

Add to config

store-account-metadata = false

But also add a list to check restriction works

store-account-metadata-list = ["cyberfounder", "alice", "bob"]

Do same test.

Results:
- No exceptions in cli_wallet
- Mongo hasn't `json_metadata` for cyberfounder, bob, alice
- get_account result for bob and alice has empty `json_metadata

**3. Check for storing of listed**

Remove store-account-metadata from config.

Change the list to:

store-account-metadata-list = ["cyberfounder", "bob"]

Do same test.

Results:
- No exceptions in cli_wallet
- Mongo hasn't `json_metadata` for cyberfounder, bob; alice - not
- get_account result for bob has specified `json_metadata; alice - empty one

**4. Check removing**

Add to config: 
store-account-metadata = true

```
./cli_wallet --server-rpc-endpoint=ws://127.0.0.1:8091
set_password qwer
unlock qwer
import_key 5JVFFWRLwz6JoP9kguuRFfytToGU6cLgBVTL9t6NB3D3BQLbUBS
create_account cyberfounder alice "{\"test\":123}" "300.000 GOLOS" true
create_account cyberfounder bob "{\"test\":123}" "300.000 GOLOS" true
```

Set in config: 
store-account-metadata = false

```
./cli_wallet --server-rpc-endpoint=ws://127.0.0.1:8091
set_password qwer
unlock qwer
import_key 5JVFFWRLwz6JoP9kguuRFfytToGU6cLgBVTL9t6NB3D3BQLbUBS
create_account cyberfounder alice "{\"test\":123}" "300.000 GOLOS" true
create_account cyberfounder bob "{\"test\":123}" "300.000 GOLOS" true
```

Result: no json_metadata