### PR TITLE
Add config flag to storing memo for transfers #797

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -368,6 +368,14 @@ namespace golos { namespace chain {
             return std::find(v.begin(), v.end(), name) != v.end();
         }
 
+        void database::set_store_memo_in_savings_withdraws(bool store_memo_in_savings_withdraws) {
+            _store_memo_in_savings_withdraws = store_memo_in_savings_withdraws;
+        }
+
+        bool database::store_memo_in_savings_withdraws() const {
+            return _store_memo_in_savings_withdraws;
+        }
+
         void database::set_skip_virtual_ops() {
             _skip_virtual_ops = true;
         }

--- a/libraries/chain/include/golos/chain/database.hpp
+++ b/libraries/chain/include/golos/chain/database.hpp
@@ -105,9 +105,13 @@ namespace golos { namespace chain {
             void set_clear_votes(uint32_t clear_votes_block);
             void set_skip_virtual_ops();
             bool clear_votes();
+
             void set_store_account_metadata(store_metadata_modes store_account_metadata);
             void set_accounts_to_store_metadata(const std::vector<std::string>& accounts_to_store_metadata);
             bool store_metadata_for_account(const std::string& name) const;
+
+            void set_store_memo_in_savings_withdraws(bool store_memo_in_savings_withdraws);
+            bool store_memo_in_savings_withdraws() const;
 
             /**
              * @brief wipe Delete database from disk, and potentially the raw chain as well.
@@ -627,8 +631,11 @@ namespace golos { namespace chain {
             uint32_t _clear_votes_block = 0;
             bool _skip_virtual_ops = false;
             bool _enable_plugins_on_push_transaction = true;
+
             store_metadata_modes _store_account_metadata = store_metadata_for_all;
             std::vector<std::string> _accounts_to_store_metadata;
+
+            bool _store_memo_in_savings_withdraws = true;
 
             flat_map<std::string, std::shared_ptr<custom_operation_interpreter>> _custom_operation_interpreters;
             std::string _json_schema;

--- a/libraries/chain/include/golos/chain/steem_object_types.hpp
+++ b/libraries/chain/include/golos/chain/steem_object_types.hpp
@@ -33,7 +33,7 @@ namespace golos { namespace chain {
             return std::string(str.begin(), str.end());
         }
 
-        inline void from_string(shared_string &out, const string &in) {
+        inline void from_string(shared_string &out, const std::string &in) {
             out.assign(in.begin(), in.end());
         }
 

--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -2110,13 +2110,14 @@ namespace golos { namespace chain {
             FC_ASSERT(_db.get_savings_balance(from, op.amount.symbol) >=
                       op.amount);
             _db.adjust_savings_balance(from, -op.amount);
+
             _db.create<savings_withdraw_object>([&](savings_withdraw_object &s) {
                 s.from = op.from;
                 s.to = op.to;
                 s.amount = op.amount;
-#ifndef IS_LOW_MEM
-                from_string(s.memo, op.memo);
-#endif
+                if (_db.store_memo_in_savings_withdraws())  {
+                    from_string(s.memo, op.memo);
+                }
                 s.request_id = op.request_id;
                 s.complete =
                         _db.head_block_time() + STEEMIT_SAVINGS_WITHDRAW_TIME;

--- a/plugins/chain/plugin.cpp
+++ b/plugins/chain/plugin.cpp
@@ -59,6 +59,8 @@ namespace chain {
 
         std::vector<std::string> accounts_to_store_metadata;
 
+        bool store_memo_in_savings_withdraws = true;
+
         plugin_impl() {
             // get default settings
             read_wait_micro = db.read_wait_micro();
@@ -242,6 +244,9 @@ namespace chain {
             ) (
                 "store-account-metadata-list", boost::program_options::value<std::string>(),
                 "names of accounts to store metadata"
+            ) (
+                "store-memo-in-savings-withdraws", boost::program_options::bool_switch()->default_value(true),
+                "store memo for all savings withdraws"
             );
         cli.add_options()
             (
@@ -340,6 +345,8 @@ namespace chain {
                     " because store-account-metadata is false");
             }
         }
+
+        my->store_memo_in_savings_withdraws = options.at("store-memo-in-savings-withdraws").as<bool>();
     }
 
     void plugin::plugin_startup() {
@@ -369,6 +376,8 @@ namespace chain {
         my->db.set_store_account_metadata(my->store_account_metadata);
 
         my->db.set_accounts_to_store_metadata(my->accounts_to_store_metadata);
+
+        my->db.set_store_memo_in_savings_withdraws(my->store_memo_in_savings_withdraws);
 
         if(my->skip_virtual_ops) {
             my->db.set_skip_virtual_ops();

--- a/plugins/mongo_db/mongo_db_state.cpp
+++ b/plugins/mongo_db/mongo_db_state.cpp
@@ -1168,9 +1168,9 @@ namespace mongo_db {
             format_value(body, "removed", false);
             format_value(body, "from", op.from);
             format_value(body, "to", op.to);
-#ifndef IS_LOW_MEM
-            format_value(body, "memo", op.memo);
-#endif
+            if (db_.store_memo_in_savings_withdraws()) {
+                format_value(body, "memo", op.memo);
+            }
             format_value(body, "request_id", swo.request_id);
             format_value(body, "amount", op.amount);
             format_value(body, "complete", swo.complete);


### PR DESCRIPTION
https://github.com/GolosChain/golos/issues/797

Checklists:

**1. Run without settings anything**

```
./cli_wallet --server-rpc-endpoint=ws://127.0.0.1:8091
set_password qwer
unlock qwer
import_key 5JVFFWRLwz6JoP9kguuRFfytToGU6cLgBVTL9t6NB3D3BQLbUBS
update_witness cyberfounder "http://url" GLS58g5rWYS3XFTuGDSxLVwiBiPLoAyCZgn6aB9Ueh8Hj5qwQA3r6 {"account_creation_fee": "10.000 GOLOS"} true
publish_feed cyberfounder {"base": "1.000 GBG", "quote": "1.000 GOLOS"} true

create_account cyberfounder alice "{}" "300.000 GOLOS" true

transfer_to_savings cyberfounder alice "2.000 GOLOS" "{}" true

transfer_from_savings alice 1 cyberfounder "1.000 GOLOS" "{\"test\":123}" true
```

Result: Mongo has object with memo.

**2. Same code with adding to config:**

store-memo-in-savings-withdraws = true

Result: same.

**3. Same code with adding to config:**

store-memo-in-savings-withdraws = false

Result: Mongo object hasn't memo.
