### PR TITLE
Mongo_db transfer and fill transfer collections, etc.  #830 #833

### DIFF
--- a/plugins/mongo_db/include/golos/plugins/mongo_db/mongo_db_state.hpp
+++ b/plugins/mongo_db/include/golos/plugins/mongo_db/mongo_db_state.hpp
@@ -128,6 +128,11 @@ namespace mongo_db {
         void format_required_approval(const required_approval_object& reqapp,
             const account_name_type& proposal_author, const std::string& proposal_title);
 
+        void format_liquidity_reward_balance(const liquidity_reward_balance_object& lrbo,
+            const account_name_type& owner);
+
+        void format_liquidity_reward_balance(const account_name_type& owner);
+
         named_document create_document(const std::string& name,
             const std::string& key, const std::string& keyval);
 

--- a/plugins/mongo_db/mongo_db_plugin.cpp
+++ b/plugins/mongo_db/mongo_db_plugin.cpp
@@ -1,5 +1,4 @@
 #include <golos/plugins/mongo_db/mongo_db_plugin.hpp>
-#include <golos/plugins/json_rpc/plugin.hpp>
 #include <golos/plugins/chain/plugin.hpp>
 #include <golos/protocol/block.hpp>
 


### PR DESCRIPTION
#830 #833 

**Check for liquidity_reward:**

1. Temporarily (!) add this code to end of `account_create_operation` handler in _steem_evaluator.cpp_:
```
_db.create<liquidity_reward_balance_object>([&](liquidity_reward_balance_object &r) {
    r.owner = _db.get_account(o.new_account_name).id;
    //r.sbd_volume = 1;
    r.steem_volume = 2;

    r.update_weight(_db.has_hardfork(STEEMIT_HARDFORK_0_9__141));
    r.last_update = _db.head_block_time();
});
push_virtual_operation(liquidity_reward_operation(o.new_account_name, asset(10, STEEM_SYMBOL)));
```
2. Create any account in cli_wallet:
```
./cli_wallet --server-rpc-endpoint=ws://127.0.0.1:8091
set_password qwer
unlock qwer
import_key 5JVFFWRLwz6JoP9kguuRFfytToGU6cLgBVTL9t6NB3D3BQLbUBS
create_account cyberfounder test "{}" "30.000 GOLOS" true
```
3. Result: liquidity_reward_balance_object in mongo.

4. _Do not forgot_ to remove it!