### PR TITLE
Better api callbacks + producer_reward virtual op #743

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -437,7 +437,7 @@ namespace golos { namespace chain {
 
                 if (free_gb == 0) {
                     uint32_t free_mb = uint32_t(free_mem / (1024 * 1024));
-                    if (free_mb <= 500 && current_block_num % 10 == 0) {
+                    if (free_mb <= (_is_testing ? 2 : 500) && current_block_num % 10 == 0) {
                         elog("Free memory is now ${n}M. Increase shared file size immediately!", ("n", free_mb));
                     }
                 }

--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -2417,8 +2417,11 @@ namespace golos { namespace chain {
         *  This method pays out vesting, reward shares and witnesses every block.
         */
         void database::process_funds() {
-            const auto &props = get_dynamic_global_properties();
-            const auto &wso = get_witness_schedule_object();
+            const auto& wso = get_witness_schedule_object();
+            const auto& props = get_dynamic_global_properties();
+            const auto& cwit = get_witness(props.current_witness);
+            const auto& wacc = get_account(cwit.owner);
+            optional<asset> producer_reward;
 
             if (has_hardfork(STEEMIT_HARDFORK_0_16__551)) {
                 /**
@@ -2445,8 +2448,6 @@ namespace golos { namespace chain {
                         (new_steem * STEEMIT_VESTING_FUND_PERCENT) /
                         STEEMIT_100_PERCENT; /// 26.67% to vesting fund
                 auto witness_reward = new_steem - content_reward - vesting_reward; /// Remaining 6.66% to witness pay
-
-                const auto &cwit = get_witness(props.current_witness);
                 witness_reward *= STEEMIT_MAX_WITNESSES;
 
                 if (cwit.schedule == witness_object::timeshare) {
@@ -2470,13 +2471,21 @@ namespace golos { namespace chain {
                     p.virtual_supply += asset(new_steem, STEEM_SYMBOL);
                 });
 
-                create_vesting(get_account(cwit.owner), asset(witness_reward, STEEM_SYMBOL));
+                producer_reward = create_vesting(wacc, asset(witness_reward, STEEM_SYMBOL));
             } else {
+                auto witness_pay = get_producer_reward();
+                /// pay witness in vesting shares
+                if (props.head_block_number >= STEEMIT_START_MINER_VOTING_BLOCK || (wacc.vesting_shares.amount == 0)) {
+                    producer_reward = create_vesting(wacc, witness_pay);
+                } else {
+                    modify(wacc, [&](account_object &a) {
+                        a.balance += witness_pay;
+                    });
+                }
+
                 auto content_reward = get_content_reward();
                 auto curate_reward = get_curation_reward();
-                auto witness_pay = get_producer_reward();
                 auto vesting_reward = content_reward + curate_reward + witness_pay;
-
                 content_reward = content_reward + curate_reward;
 
                 if (props.head_block_number < STEEMIT_START_VESTING_BLOCK) {
@@ -2485,13 +2494,16 @@ namespace golos { namespace chain {
                     vesting_reward.amount.value *= 9;
                 }
 
-                modify(props, [&](dynamic_global_property_object &p) {
+                modify(props, [&](dynamic_global_property_object& p) {
                     p.total_vesting_fund_steem += vesting_reward;
                     p.total_reward_fund_steem += content_reward;
                     p.current_supply += content_reward + witness_pay + vesting_reward;
                     p.virtual_supply += content_reward + witness_pay + vesting_reward;
                 });
             }
+
+            if (producer_reward)
+                push_virtual_operation(producer_reward_operation(wacc.name, *producer_reward));
         }
 
         void database::process_savings_withdraws() {
@@ -2552,47 +2564,15 @@ namespace golos { namespace chain {
             return reward;
         }
 
-        asset database::get_producer_reward() {
-            const auto &props = get_dynamic_global_properties();
-            static_assert(STEEMIT_BLOCK_INTERVAL ==
-                          3, "this code assumes a 3-second time interval");
+        asset database::get_producer_reward() const {
+            static_assert(STEEMIT_BLOCK_INTERVAL == 3, "this code assumes a 3-second time interval");
+            const auto& props = get_dynamic_global_properties();
             asset percent(protocol::calc_percent_reward_per_block<STEEMIT_PRODUCER_APR_PERCENT>(props.virtual_supply.amount), STEEM_SYMBOL);
 
-            const auto &witness_account = get_account(props.current_witness);
-
-            if (has_hardfork(STEEMIT_HARDFORK_0_16)) {
-                auto pay = std::max(percent, STEEMIT_MIN_PRODUCER_REWARD);
-
-                /// pay witness in vesting shares
-                if (props.head_block_number >=
-                    STEEMIT_START_MINER_VOTING_BLOCK ||
-                    (witness_account.vesting_shares.amount.value == 0)) {
-                    // const auto& witness_obj = get_witness( props.current_witness );
-                    create_vesting(witness_account, pay);
-                } else {
-                    modify(get_account(witness_account.name), [&](account_object &a) {
-                        a.balance += pay;
-                    });
-                }
-
-                return pay;
-            } else {
-                auto pay = std::max(percent, STEEMIT_MIN_PRODUCER_REWARD_PRE_HF_16);
-
-                /// pay witness in vesting shares
-                if (props.head_block_number >=
-                    STEEMIT_START_MINER_VOTING_BLOCK ||
-                    (witness_account.vesting_shares.amount.value == 0)) {
-                    // const auto& witness_obj = get_witness( props.current_witness );
-                    create_vesting(witness_account, pay);
-                } else {
-                    modify(get_account(witness_account.name), [&](account_object &a) {
-                        a.balance += pay;
-                    });
-                }
-
-                return pay;
-            }
+            // why this needed? the method called only before hf16
+            auto min_reward = has_hardfork(STEEMIT_HARDFORK_0_16) ? STEEMIT_MIN_PRODUCER_REWARD : STEEMIT_MIN_PRODUCER_REWARD_PRE_HF_16;
+            auto pay = std::max(percent, min_reward);
+            return pay;
         }
 
         asset database::get_pow_reward() const {

--- a/libraries/chain/include/golos/chain/database.hpp
+++ b/libraries/chain/include/golos/chain/database.hpp
@@ -49,7 +49,7 @@ namespace golos { namespace chain {
             }
 
             bool _is_producing = false;
-
+            bool _is_testing = false;           ///< set for tests to avoid low free memory spam
             bool _log_hardforks = true;
 
             enum validation_steps {

--- a/libraries/chain/include/golos/chain/database.hpp
+++ b/libraries/chain/include/golos/chain/database.hpp
@@ -432,13 +432,9 @@ namespace golos { namespace chain {
             share_type claim_rshare_reward(share_type rshares, uint16_t reward_weight, asset max_steem);
 
             asset get_liquidity_reward() const;
-
             asset get_content_reward() const;
-
-            asset get_producer_reward();
-
+            asset get_producer_reward() const;
             asset get_curation_reward() const;
-
             asset get_pow_reward() const;
 
             uint16_t get_curation_rewards_percent() const;

--- a/libraries/chain/include/golos/chain/operation_notification.hpp
+++ b/libraries/chain/include/golos/chain/operation_notification.hpp
@@ -1,26 +1,24 @@
 #pragma once
 
 #include <golos/protocol/operations.hpp>
-
 #include <golos/chain/steem_object_types.hpp>
 
-namespace golos {
-    using protocol::operation;
-    namespace chain {
+namespace golos { namespace chain {
 
-        struct operation_notification {
-            operation_notification(const operation &o) : op(o) {
-            }
+using protocol::operation;
 
-            bool stored_in_db = false;
-            int64_t db_id = 0;
-            transaction_id_type trx_id;
-            uint32_t block = 0;
-            uint32_t trx_in_block = 0;
-            uint16_t op_in_trx = 0;
-            uint32_t virtual_op = 0;
-            const operation &op;
-        };
-
+struct operation_notification {
+    operation_notification(const operation &o) : op(o) {
     }
-}
+
+    bool stored_in_db = false;
+    int64_t db_id = 0;
+    transaction_id_type trx_id;
+    uint32_t block = 0;
+    uint32_t trx_in_block = 0;
+    uint16_t op_in_trx = 0;
+    uint32_t virtual_op = 0;
+    const operation &op;
+};
+
+} } // golos::chain

--- a/libraries/protocol/include/golos/protocol/block.hpp
+++ b/libraries/protocol/include/golos/protocol/block.hpp
@@ -3,16 +3,14 @@
 #include <golos/protocol/block_header.hpp>
 #include <golos/protocol/transaction.hpp>
 
-namespace golos {
-    namespace protocol {
+namespace golos { namespace protocol {
 
-        struct signed_block : public signed_block_header {
-            checksum_type calculate_merkle_root() const;
+struct signed_block : public signed_block_header {
+    checksum_type calculate_merkle_root() const;
 
-            vector <signed_transaction> transactions;
-        };
+    vector<signed_transaction> transactions;
+};
 
-    }
-} // golos::protocol
+} } // golos::protocol
 
 FC_REFLECT_DERIVED((golos::protocol::signed_block), ((golos::protocol::signed_block_header)), (transactions))

--- a/libraries/protocol/include/golos/protocol/operations.hpp
+++ b/libraries/protocol/include/golos/protocol/operations.hpp
@@ -81,7 +81,8 @@ namespace golos { namespace protocol {
                 hardfork_operation,
                 comment_payout_update_operation,
                 comment_benefactor_reward_operation,
-                return_vesting_delegation_operation
+                return_vesting_delegation_operation,
+                producer_reward_operation
         > operation;
 
         /*void operation_get_required_authorities( const operation& op,

--- a/libraries/protocol/include/golos/protocol/steem_virtual_operations.hpp
+++ b/libraries/protocol/include/golos/protocol/steem_virtual_operations.hpp
@@ -187,6 +187,14 @@ namespace golos { namespace protocol {
             asset reward;
         };
 
+        struct producer_reward_operation : public virtual_operation {
+            producer_reward_operation() {}
+            producer_reward_operation(const string& p, const asset& v) : producer(p), vesting_shares(v) {}
+
+            account_name_type producer;
+            asset             vesting_shares;
+        };
+
         struct return_vesting_delegation_operation: public virtual_operation {
             return_vesting_delegation_operation() {
             }
@@ -213,3 +221,4 @@ FC_REFLECT((golos::protocol::hardfork_operation), (hardfork_id))
 FC_REFLECT((golos::protocol::comment_payout_update_operation), (author)(permlink))
 FC_REFLECT((golos::protocol::comment_benefactor_reward_operation), (benefactor)(author)(permlink)(reward))
 FC_REFLECT((golos::protocol::return_vesting_delegation_operation), (account)(vesting_shares))
+FC_REFLECT((golos::protocol::producer_reward_operation), (producer)(vesting_shares))

--- a/libraries/protocol/include/golos/protocol/transaction.hpp
+++ b/libraries/protocol/include/golos/protocol/transaction.hpp
@@ -6,8 +6,7 @@
 
 #include <numeric>
 
-namespace golos {
-    namespace protocol {
+namespace golos { namespace protocol {
 
         struct transaction {
             uint16_t ref_block_num = 0;
@@ -127,8 +126,7 @@ namespace golos {
 
         /// @} transactions group
 
-    }
-} // golos::protocol
+} } // golos::protocol
 
 FC_REFLECT((golos::protocol::transaction), (ref_block_num)(ref_block_prefix)(expiration)(operations)(extensions))
 FC_REFLECT_DERIVED((golos::protocol::signed_transaction), ((golos::protocol::transaction)), (signatures))

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -1371,7 +1371,7 @@ fc::ecc::private_key wallet_api::derive_private_key(const std::string& prefix_st
             } else {
                 accounts.push_back(get_account(account));
             }
-            
+
             for (auto it = accounts.begin(); it != accounts.end(); it++) {
                 key_with_data memo_key_data;
                 memo_key_data.public_key = std::string(it->memo_key);
@@ -1381,7 +1381,7 @@ fc::ecc::private_key wallet_api::derive_private_key(const std::string& prefix_st
                 all_keys.push_back(memo_key_data);
 
                 auto acc_owner_keys = it->owner.get_keys();
-                for (auto it2 = acc_owner_keys.begin(); it2 != acc_owner_keys.end(); it2++) { 
+                for (auto it2 = acc_owner_keys.begin(); it2 != acc_owner_keys.end(); it2++) {
                     key_with_data key_data;
                     key_data.public_key = std::string(*it2);
                     key_data.private_key = get_private_key(*it2);
@@ -1391,7 +1391,7 @@ fc::ecc::private_key wallet_api::derive_private_key(const std::string& prefix_st
                 }
 
                 auto acc_active_keys = it->active.get_keys();
-                for (auto it2 = acc_active_keys.begin(); it2 != acc_active_keys.end(); it2++) { 
+                for (auto it2 = acc_active_keys.begin(); it2 != acc_active_keys.end(); it2++) {
                     key_with_data key_data;
                     key_data.public_key = std::string(*it2);
                     key_data.private_key = get_private_key(*it2);
@@ -1401,7 +1401,7 @@ fc::ecc::private_key wallet_api::derive_private_key(const std::string& prefix_st
                 }
 
                 auto acc_posting_keys = it->posting.get_keys();
-                for (auto it2 = acc_posting_keys.begin(); it2 != acc_posting_keys.end(); it2++) { 
+                for (auto it2 = acc_posting_keys.begin(); it2 != acc_posting_keys.end(); it2++) {
                     key_with_data key_data;
                     key_data.public_key = std::string(*it2);
                     key_data.private_key = get_private_key(*it2);
@@ -2618,4 +2618,3 @@ fc::ecc::private_key wallet_api::derive_private_key(const std::string& prefix_st
         }
 
     } } // steem::wallet
-

--- a/plugins/account_history/plugin.cpp
+++ b/plugins/account_history/plugin.cpp
@@ -26,7 +26,7 @@ T dejsonify(const string &s) {
 
 #define DEFAULT_VALUE_VECTOR(value) default_value({fc::json::to_string(value)}, fc::json::to_string(value))
 #define LOAD_VALUE_SET(options, name, container, type) \
-if( options.count(name) ) { \
+if (options.count(name)) { \
     const std::vector<std::string>& ops = options[name].as<std::vector<std::string>>(); \
     std::transform(ops.begin(), ops.end(), std::inserter(container, container.end()), &dejsonify<type>); \
 }

--- a/plugins/account_history/plugin.cpp
+++ b/plugins/account_history/plugin.cpp
@@ -341,6 +341,10 @@ if( options.count(name) ) { \
             impacted.insert(op.author);
         }
 
+        void operator()(const producer_reward_operation& op) {
+            impacted.insert(op.producer);
+        }
+
         void operator()(const delegate_vesting_shares_operation& op) {
             impacted.insert(op.delegator);
             impacted.insert(op.delegatee);

--- a/plugins/database_api/include/golos/plugins/database_api/plugin.hpp
+++ b/plugins/database_api/include/golos/plugins/database_api/plugin.hpp
@@ -94,7 +94,7 @@ struct signed_block_api_object : public signed_block {
 };
 
 
-using block_applied_callback = std::function<void(const variant &block_header)>;
+using block_applied_callback = std::function<void(const signed_block&)>;
 
 ///               API,                                    args,                return
 DEFINE_API_ARGS(get_block_header,                 msg_pack, optional<block_header>)

--- a/plugins/json_rpc/include/golos/plugins/json_rpc/utility.hpp
+++ b/plugins/json_rpc/include/golos/plugins/json_rpc/utility.hpp
@@ -40,9 +40,8 @@ BOOST_PP_CAT( method, _return ) method( BOOST_PP_CAT( method, _args )& );
 #define DEFINE_API(class, api_name)                                   \
 api_name ## _return class :: api_name ( api_name ## _args& args )
 
-namespace golos {
-    namespace plugins {
-        namespace json_rpc {
+namespace golos { namespace plugins { namespace json_rpc {
+
             class msg_pack final {
             public:
                 fc::variant id;
@@ -124,8 +123,6 @@ namespace golos {
             struct void_type {
             };
 
-        }
-    }
-} // golos::plugins::json_rpc
+} } } // golos::plugins::json_rpc
 
 FC_REFLECT((golos::plugins::json_rpc::void_type),)

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -1,9 +1,8 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/program_options.hpp>
 
-#include <golos/time/time.hpp>
 #include <graphene/utilities/tempdir.hpp>
-
+#include <golos/time/time.hpp>
 #include <golos/chain/steem_objects.hpp>
 #include <golos/plugins/account_history/history_object.hpp>
 
@@ -12,7 +11,6 @@
 
 #include "database_fixture.hpp"
 
-//using namespace golos::chain::test;
 
 #define STEEM_NAMESPACE_PREFIX std::string("golos::protocol::")
 
@@ -301,7 +299,7 @@ namespace golos { namespace chain {
 
         void database_fixture::initialize() {
             int argc = boost::unit_test::framework::master_test_suite().argc;
-            char **argv = boost::unit_test::framework::master_test_suite().argv;
+            char** argv = boost::unit_test::framework::master_test_suite().argv;
             for (int i = 1; i < argc; i++) {
                 const std::string arg = argv[i];
                 if (arg == "--record-assert-trip") {
@@ -320,15 +318,15 @@ namespace golos { namespace chain {
             db_plugin = &appbase::app().register_plugin<debug_node::plugin>();
 
             appbase::app().initialize<
-                    golos::plugins::chain::plugin,
-                    account_history::plugin,
-                    debug_node::plugin
-            >( argc, argv );
+                golos::plugins::chain::plugin,
+                account_history::plugin,
+                debug_node::plugin
+            >(argc, argv);
 
             db_plugin->set_logging(false);
 
             db = &ch_plugin->db();
-            BOOST_REQUIRE( db );
+            BOOST_REQUIRE(db);
         }
 
         void database_fixture::startup(bool generate_hardfork) {
@@ -341,13 +339,13 @@ namespace golos { namespace chain {
             vest(STEEMIT_INIT_MINER_NAME, 10000);
 
             // Fill up the rest of the required miners
-            for (int i = STEEMIT_NUM_INIT_MINERS;
-                 i < STEEMIT_MAX_WITNESSES; i++) {
+            for (int i = STEEMIT_NUM_INIT_MINERS; i < STEEMIT_MAX_WITNESSES; i++) {
                 account_create(STEEMIT_INIT_MINER_NAME + fc::to_string(i), init_account_pub_key);
                 fund(STEEMIT_INIT_MINER_NAME + fc::to_string(i), STEEMIT_MIN_PRODUCER_REWARD.amount.value);
-                witness_create(STEEMIT_INIT_MINER_NAME + fc::to_string(i),
-                               init_account_priv_key, "foo.bar", init_account_pub_key,
-                               STEEMIT_MIN_PRODUCER_REWARD.amount);
+                witness_create(
+                    STEEMIT_INIT_MINER_NAME + fc::to_string(i),
+                    init_account_priv_key, "foo.bar", init_account_pub_key,
+                    STEEMIT_MIN_PRODUCER_REWARD.amount);
             }
 
             oh_plugin->plugin_startup();
@@ -361,9 +359,9 @@ namespace golos { namespace chain {
             if (!data_dir) {
                 data_dir = fc::temp_directory(golos::utilities::temp_directory_path());
                 db->_log_hardforks = false;
+                db->_is_testing = true;
                 db->open(data_dir->path(), data_dir->path(), INITIAL_TEST_SUPPLY,
-                        1024 * 1024 *
-                        8, chainbase::database::read_write); // 8 MB file for testing
+                    1024 * 1024 * 10, chainbase::database::read_write); // 10 MB file for testing
             }
         }
 
@@ -641,14 +639,12 @@ namespace golos { namespace chain {
 
         vector<operation> database_fixture::get_last_operations(uint32_t num_ops) {
             vector<operation> ops;
-            const auto &acc_hist_idx = db->get_index<golos::plugins::account_history::account_history_index>().indices().get<by_id>();
+            const auto& acc_hist_idx = db->get_index<golos::plugins::account_history::account_history_index>().indices().get<by_id>();
             auto itr = acc_hist_idx.end();
-
             while (itr != acc_hist_idx.begin() && ops.size() < num_ops) {
                 itr--;
                 ops.push_back(fc::raw::unpack<golos::chain::operation>(db->get(itr->op).serialized_op));
             }
-
             return ops;
         }
 

--- a/tests/common/database_fixture.hpp
+++ b/tests/common/database_fixture.hpp
@@ -27,15 +27,13 @@ extern uint32_t ( STEEMIT_TESTING_GENESIS_TIMESTAMP );
    golos::chain::test::_push_block
 
 // See below
-#define REQUIRE_OP_VALIDATION_SUCCESS(op, field, value) \
-{ \
+#define REQUIRE_OP_VALIDATION_SUCCESS(op, field, value) { \
    const auto temp = op.field; \
    op.field = value; \
    op.validate(); \
    op.field = temp; \
 }
-#define REQUIRE_OP_EVALUATION_SUCCESS(op, field, value) \
-{ \
+#define REQUIRE_OP_EVALUATION_SUCCESS(op, field, value) { \
    const auto temp = op.field; \
    op.field = value; \
    trx.operations.back() = op; \
@@ -43,8 +41,7 @@ extern uint32_t ( STEEMIT_TESTING_GENESIS_TIMESTAMP );
    db.push_transaction( trx, ~0 ); \
 }
 
-/*#define STEEMIT_REQUIRE_THROW( expr, exc_type )          \
-{                                                         \
+/*#define STEEMIT_REQUIRE_THROW( expr, exc_type ) {       \
    std::string req_throw_info = fc::json::to_string(      \
       fc::mutable_variant_object()                        \
       ("source_file", __FILE__)                           \
@@ -64,8 +61,7 @@ extern uint32_t ( STEEMIT_TESTING_GENESIS_TIMESTAMP );
 #define STEEMIT_REQUIRE_THROW(expr, exc_type)          \
    BOOST_REQUIRE_THROW( expr, exc_type );
 
-#define STEEMIT_CHECK_THROW(expr, exc_type)            \
-{                                                         \
+#define STEEMIT_CHECK_THROW(expr, exc_type) {             \
    std::string req_throw_info = fc::json::to_string(      \
       fc::mutable_variant_object()                        \
       ("source_file", __FILE__)                           \
@@ -74,11 +70,11 @@ extern uint32_t ( STEEMIT_TESTING_GENESIS_TIMESTAMP );
       ("exc_type", #exc_type)                             \
       );                                                  \
    if( fc::enable_record_assert_trip )                    \
-      std::cout << "STEEMIT_CHECK_THROW begin "          \
+      std::cout << "STEEMIT_CHECK_THROW begin "           \
          << req_throw_info << std::endl;                  \
    BOOST_CHECK_THROW( expr, exc_type );                   \
    if( fc::enable_record_assert_trip )                    \
-      std::cout << "STEEMIT_CHECK_THROW end "            \
+      std::cout << "STEEMIT_CHECK_THROW end "             \
          << req_throw_info << std::endl;                  \
 }
 
@@ -171,7 +167,7 @@ struct ErrorValidator<golos::logic_exception> {
     void validate(const std::string& name, const fc::variant& props,
             golos::logic_exception::error_types err) {
         BOOST_CHECK_EQUAL(name, "logic_exception");
-        BOOST_CHECK_EQUAL(props["errid"].get_string(), 
+        BOOST_CHECK_EQUAL(props["errid"].get_string(),
             fc::reflector<golos::logic_exception::error_types>::to_string(err));
     }
 };
@@ -204,10 +200,10 @@ struct ErrorValidator<golos::protocol::tx_irrelevant_sig> {
     catch( E const& ex ) {                                                                              \
         ::boost::unit_test::ut_detail::ignore_unused_variable_warning( ex );                            \
         BOOST_CHECK_IMPL( true, "exception '" BOOST_STRINGIZE( E ) "' is caught", TL, CHECK_MSG );      \
-        const std::string name = ex.name(); \
+        const std::string name = ex.name();                                                             \
         const fc::variant_object &props = ex.get_log().at(0).get_data();                                \
         try {                                                                                           \
-            C(name, props);                                                                                          \
+            C(name, props);                                                                             \
         } catch (const fc::exception& err) {                                                            \
             BOOST_CHECK_IMPL( false, "caught exception '" << err.name() << "' while check props:" <<    \
                 err.to_detail_string(), TL, CHECK_MSG);                                                 \
@@ -268,8 +264,8 @@ struct ErrorValidator<golos::protocol::tx_irrelevant_sig> {
 //   that is why comparision can be done only with some correction
 #define GOLOS_VEST_REQUIRE_EQUAL(left, right) \
     BOOST_REQUIRE( \
-            std::abs((left).amount.value - (right).amount.value) < 5 && \
-            (left).symbol == (right).symbol \
+        std::abs((left).amount.value - (right).amount.value) < 5 && \
+        (left).symbol == (right).symbol \
     )
 
 
@@ -301,20 +297,18 @@ namespace golos { namespace chain {
         using namespace golos::protocol;
 
         struct database_fixture {
-            // the reason we use an app is to exercise the indexes of built-in
-            //   plugins
-            chain::database *db;
+            // the reason we use an app is to exercise the indexes of built-in plugins
+            chain::database* db;
             signed_transaction trx;
             fc::ecc::private_key init_account_priv_key = STEEMIT_INIT_PRIVATE_KEY;
             string debug_key = golos::utilities::key_to_wif(init_account_priv_key);
             public_key_type init_account_pub_key = init_account_priv_key.get_public_key();
-            uint32_t default_skip = 0 | database::skip_undo_history_check |
-                                    database::skip_authority_check;
+            uint32_t default_skip = 0 | database::skip_undo_history_check | database::skip_authority_check;
 
-            golos::plugins::chain::plugin *ch_plugin = nullptr;
-            golos::plugins::debug_node::plugin *db_plugin = nullptr;
-            golos::plugins::operation_history::plugin *oh_plugin = nullptr;
-            golos::plugins::account_history::plugin *ah_plugin = nullptr;
+            golos::plugins::chain::plugin* ch_plugin = nullptr;
+            golos::plugins::debug_node::plugin* db_plugin = nullptr;
+            golos::plugins::operation_history::plugin* oh_plugin = nullptr;
+            golos::plugins::account_history::plugin* ah_plugin = nullptr;
 
             optional<fc::temp_directory> data_dir;
             bool skip_key_index_test = false;
@@ -336,9 +330,10 @@ namespace golos { namespace chain {
             void open_database();
             void close_database();
 
-            void generate_block(uint32_t skip = 0,
-                    const fc::ecc::private_key &key = STEEMIT_INIT_PRIVATE_KEY,
-                    int miss_blocks = 0);
+            void generate_block(
+                uint32_t skip = 0,
+                const fc::ecc::private_key& key = STEEMIT_INIT_PRIVATE_KEY,
+                int miss_blocks = 0);
 
             /**
              * @brief Generates block_count blocks
@@ -403,6 +398,23 @@ namespace golos { namespace chain {
             void sign(signed_transaction &trx, const fc::ecc::private_key &key);
 
             vector<operation> get_last_operations(uint32_t ops);
+
+            // we have producer_reward virtual op now, so get_last_operations
+            // can be hard to use after generate_blocks.
+            // this get_last_operations variant helps to get only required op type
+            template<typename op_type>
+            vector<op_type> get_last_operations(uint32_t num_ops) {
+                vector<op_type> ops;
+                const auto& acc_hist_idx = db->get_index<golos::plugins::account_history::account_history_index>().indices().get<by_id>();
+                auto itr = acc_hist_idx.end();
+                while (itr != acc_hist_idx.begin() && ops.size() < num_ops) {
+                    itr--;
+                    auto op = fc::raw::unpack<golos::chain::operation>(db->get(itr->op).serialized_op);
+                    if (op.which() == operation::tag<op_type>::value)
+                        ops.push_back(op.get<op_type>());
+                }
+                return ops;
+            }
 
             void validate_database(void);
 
@@ -476,9 +488,9 @@ namespace golos { namespace chain {
         };
 
         namespace test {
-            bool _push_block(database &db, const signed_block &b, uint32_t skip_flags = 0);
+            bool _push_block(database& db, const signed_block& b, uint32_t skip_flags = 0);
 
-            void _push_transaction(database &db, const signed_transaction &tx, uint32_t skip_flags = 0);
+            void _push_transaction(database& db, const signed_transaction& tx, uint32_t skip_flags = 0);
         }
 
 } } // golos:chain

--- a/tests/tests/operation_time_tests.cpp
+++ b/tests/tests/operation_time_tests.cpp
@@ -3,13 +3,11 @@
 #include <boost/test/unit_test.hpp>
 
 #include <golos/protocol/exceptions.hpp>
-
 #include <golos/chain/block_summary_object.hpp>
 #include <golos/chain/database.hpp>
 #include <golos/chain/hardfork.hpp>
-#include <golos/plugins/account_history/history_object.hpp>
 #include <golos/chain/steem_objects.hpp>
-
+#include <golos/plugins/account_history/history_object.hpp>
 #include <golos/plugins/debug_node/plugin.hpp>
 
 #include <fc/crypto/digest.hpp>
@@ -923,7 +921,7 @@ BOOST_FIXTURE_TEST_SUITE(operation_time_tests, clean_database_fixture)
         }
         FC_LOG_AND_RETHROW()
     }
-    
+
     BOOST_AUTO_TEST_CASE(vesting_withdraw_route) {
         try {
             ACTORS((alice)(bob)(sam))
@@ -1932,8 +1930,8 @@ BOOST_FIXTURE_TEST_SUITE(operation_time_tests, clean_database_fixture)
                 db->head_block_time() + fc::seconds(STEEMIT_MIN_LIQUIDITY_REWARD_PERIOD_SEC_HF10.to_seconds() / 2),
                 true);
 
-            ops = get_last_operations(1);
-            fill_order_op = ops[0].get<fill_order_operation>();
+            auto fill_ops = get_last_operations<fill_order_operation>(1);
+            fill_order_op = fill_ops[0];
 
             BOOST_REQUIRE(fill_order_op.open_owner == "alice");
             BOOST_REQUIRE(fill_order_op.open_orderid == 6);


### PR DESCRIPTION
### 1. `set_block_applied_callback` improvements

* `set_block_applied_callback` notifications can now contain virtual operations.
* Changed 1st parameter from `cb` to `type`. It was not used, but required earlier. Now parameter sets, which data callback should send. The following values supported:

value|alternative value|notifications data type
-|-|-
"block"|0|`signed_block` as in HF 18.0
"header"|1|`block_header` as in HF 16.4
"virtual_ops"|2|only virtual operations
"full"|3|`signed_block` extended with `_virtual_operations` field

Any other value passed to `set_block_applied_callback` will be treated as "block".

### 2. `set_pending_transaction_callback`

This new api method notifies client on each incoming transaction (before it applied). There is no guarantee transaction will be actually applied. The method have no parameters.

### 3. `producer_reward_operation`

This new virtual operation emitted on each* block. It contain info about block producer and his reward in GESTS:
```
struct producer_reward_operation {
    account_name_type producer;
    asset             vesting_shares;
};
```

**Note**: in combination with `operation_history` and `account_history` plugins, this operation can increase shared_memory greatly. It can be disabled with config blacklist and/or history limiting.

### 4. Misc

* While tests run, there can be lot of "Increase shared file size immediately!" error messages. Now it's fixed and message will appear only if there is really not enough memory.
* Some cleaning, refactoring and code-style related fixes.

***
Closes #743 