### PR TITLE
 Add comment_reward_object to social_network

### DIFF
--- a/libraries/api/include/golos/api/comment_api_object.hpp
+++ b/libraries/api/include/golos/api/comment_api_object.hpp
@@ -8,6 +8,7 @@
 namespace golos { namespace api {
 
     using namespace golos::chain;
+    using namespace golos::protocol;
 
     struct comment_api_object {
         comment_object::id_type id;
@@ -44,10 +45,16 @@ namespace golos { namespace api {
 
         uint16_t reward_weight = 0;
 
-        protocol::asset total_payout_value;
-        protocol::asset curator_payout_value;
+        asset total_payout_value = asset(0, SBD_SYMBOL);
+        asset beneficiary_payout_value = asset(0, SBD_SYMBOL);
+        asset beneficiary_gests_payout_value = asset(0, VESTS_SYMBOL);
+        asset curator_payout_value = asset(0, SBD_SYMBOL);
+        asset curator_gests_payout_value = asset(0, VESTS_SYMBOL);
 
         share_type author_rewards;
+        asset author_gbg_payout_value = asset(0, SBD_SYMBOL);
+        asset author_golos_payout_value = asset(0, STEEM_SYMBOL);
+        asset author_gests_payout_value = asset(0, VESTS_SYMBOL);
 
         int32_t net_votes = 0;
 
@@ -73,7 +80,8 @@ FC_REFLECT(
     (id)(author)(permlink)(parent_author)(parent_permlink)(category)(title)(body)(json_metadata)(last_update)
     (created)(active)(last_payout)(depth)(children)(children_rshares2)(net_rshares)(abs_rshares)
     (vote_rshares)(children_abs_rshares)(cashout_time)(max_cashout_time)(total_vote_weight)
-    (reward_weight)(total_payout_value)(curator_payout_value)(author_rewards)(net_votes)
+    (reward_weight)(total_payout_value)(beneficiary_payout_value)(beneficiary_gests_payout_value)(curator_payout_value)(curator_gests_payout_value)
+    (author_rewards)(author_gbg_payout_value)(author_golos_payout_value)(author_gests_payout_value)(net_votes)
     (mode)(root_comment)(root_title)(max_accepted_payout)(percent_steem_dollars)(allow_replies)(allow_votes)
     (allow_curation_rewards)(beneficiaries))
 

--- a/libraries/api/include/golos/api/discussion.hpp
+++ b/libraries/api/include/golos/api/discussion.hpp
@@ -16,8 +16,18 @@ namespace golos { namespace api {
         }
 
         string url; /// /category/@rootauthor/root_permlink#author/permlink
+
+        asset pending_author_payout_value = asset(0, SBD_SYMBOL);
+        asset pending_author_payout_gbg_value = asset(0, SBD_SYMBOL);
+        asset pending_author_payout_gests_value = asset(0, VESTS_SYMBOL);
+        asset pending_author_payout_golos_value = asset(0, STEEM_SYMBOL);
+        asset pending_benefactor_payout_value = asset(0, SBD_SYMBOL);
+        asset pending_benefactor_payout_gests_value = asset(0, VESTS_SYMBOL);
+        asset pending_curator_payout_value = asset(0, SBD_SYMBOL);
+        asset pending_curator_payout_gests_value = asset(0, VESTS_SYMBOL);
         asset pending_payout_value = asset(0, SBD_SYMBOL); ///< sbd
         asset total_pending_payout_value = asset(0, SBD_SYMBOL); ///< sbd including replies
+
         std::vector<vote_state> active_votes;
         uint32_t active_votes_count = 0;
         std::vector<string> replies; ///< author/slug mapping
@@ -34,5 +44,9 @@ namespace golos { namespace api {
 } } // golos::api
 
 FC_REFLECT_DERIVED( (golos::api::discussion), ((golos::api::comment_api_object)),
-        (url)(pending_payout_value)(total_pending_payout_value)(active_votes)(active_votes_count)(replies)
+        (url)(pending_author_payout_value)(pending_author_payout_gbg_value)
+        (pending_author_payout_gests_value)(pending_author_payout_golos_value)
+        (pending_benefactor_payout_value)(pending_benefactor_payout_gests_value)
+        (pending_curator_payout_value)(pending_curator_payout_gests_value)
+        (pending_payout_value)(total_pending_payout_value)(active_votes)(active_votes_count)(replies)
         (author_reputation)(promoted)(body_length)(reblogged_by)(first_reblogged_by)(first_reblogged_on))

--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -2235,22 +2235,6 @@ namespace golos { namespace chain {
             }
         }
 
-        void database::adjust_total_payout(
-                const comment_object &cur,
-                const asset &sbd_created,
-                const asset &curator_sbd_value,
-                const asset &beneficiary_value
-        ) {
-            modify(cur, [&](comment_object &c) {
-                if (c.total_payout_value.symbol == sbd_created.symbol) {
-                    c.total_payout_value += sbd_created;
-                    c.beneficiary_payout_value += beneficiary_value;
-                    c.curator_payout_value += curator_sbd_value;
-                }
-            });
-            /// TODO: potentially modify author's total payout numbers as well
-        }
-
 /**
  *  This method will iterate through all comment_vote_objects and give them
  *  (max_rewards * weight) / c.total_vote_weight.
@@ -2273,6 +2257,7 @@ namespace golos { namespace chain {
                         if (claim > 0) // min_amt is non-zero satoshis
                         {
                             unclaimed_rewards -= claim;
+
                             const auto &voter = get(itr->voter);
                             auto reward = create_vesting(voter, asset(claim, STEEM_SYMBOL));
 
@@ -2283,6 +2268,8 @@ namespace golos { namespace chain {
                                 a.curation_rewards += claim;
                             });
 #endif
+                        } else {
+                            break;
                         }
                         ++itr;
                     }
@@ -2339,19 +2326,6 @@ namespace golos { namespace chain {
                         auto vest_created = create_vesting(author, vesting_steem);
                         auto sbd_payout = create_sbd(author, sbd_steem);
 
-                        adjust_total_payout(
-                                comment,
-                                sbd_payout.first + to_sbd(sbd_payout.second + asset(vesting_steem, STEEM_SYMBOL)),
-                                to_sbd(asset(curation_tokens, STEEM_SYMBOL)),
-                                to_sbd(asset(total_beneficiary, STEEM_SYMBOL))
-                        );
-
-                        /*if( sbd_created.symbol == SBD_SYMBOL )
-                           adjust_total_payout( comment, sbd_created + to_sbd( asset( vesting_steem, STEEM_SYMBOL ) ), to_sbd( asset( reward_tokens.to_uint64() - author_tokens, STEEM_SYMBOL ) ) );
-                        else
-                           adjust_total_payout( comment, to_sbd( asset( vesting_steem + sbd_steem, STEEM_SYMBOL ) ), to_sbd( asset( reward_tokens.to_uint64() - author_tokens, STEEM_SYMBOL ) ) );
-                           */
-
                         // stats only.. TODO: Move to plugin...
                         total_payout = to_sbd(asset(reward_tokens.to_uint64(), STEEM_SYMBOL));
 
@@ -2359,10 +2333,6 @@ namespace golos { namespace chain {
                         push_virtual_operation(comment_reward_operation(comment.author, to_string(comment.permlink), total_payout));
 
 #ifndef IS_LOW_MEM
-                        modify(comment, [&](comment_object &c) {
-                            c.author_rewards += author_tokens;
-                        });
-
                         modify(get_account(comment.author), [&](account_object &a) {
                             a.posting_rewards += author_tokens;
                         });

--- a/libraries/chain/include/golos/chain/comment_object.hpp
+++ b/libraries/chain/include/golos/chain/comment_object.hpp
@@ -85,13 +85,6 @@ namespace golos {
 
             uint16_t reward_weight = 0;
 
-            /** tracks the total payout this comment has received over time, measured in SBD */
-            asset total_payout_value = asset(0, SBD_SYMBOL);
-            asset curator_payout_value = asset(0, SBD_SYMBOL);
-            asset beneficiary_payout_value = asset(0, SBD_SYMBOL);
-
-            share_type author_rewards = 0;
-
             int32_t net_votes = 0;
 
             id_type root_comment;

--- a/libraries/chain/include/golos/chain/database.hpp
+++ b/libraries/chain/include/golos/chain/database.hpp
@@ -371,8 +371,6 @@ namespace golos { namespace chain {
 
             asset create_vesting(const account_object &to_account, asset steem);
 
-            void adjust_total_payout(const comment_object &a, const asset &sbd, const asset &curator_sbd_value, const asset& beneficiary_value);
-
             void update_witness_schedule();
 
             void adjust_liquidity_reward(const account_object &owner, const asset &volume, bool is_bid);

--- a/plugins/chain/plugin.cpp
+++ b/plugins/chain/plugin.cpp
@@ -257,9 +257,10 @@ namespace golos { namespace plugins { namespace chain {
                 "store-account-metadata-list", bpo::value<std::string>(),
                 "names of accounts to store metadata"
             ) (
-                "store-memo-in-savings-withdraws", bpo::bool_switch()->default_value(true),
+                "store-memo-in-savings-withdraws", bpo::value<bool>()->default_value(true),
                 "store memo for all savings withdraws"
             );
+        //  Do not use bool_switch() in cfg!
         cli.add_options()
             (
                 "replay-blockchain", bpo::bool_switch()->default_value(false),

--- a/plugins/mongo_db/mongo_db_state.cpp
+++ b/plugins/mongo_db/mongo_db_state.cpp
@@ -75,14 +75,11 @@ namespace mongo_db {
             format_value(body, "allow_curation_rewards", comment.allow_curation_rewards);
             format_value(body, "allow_replies", comment.allow_replies);
             format_value(body, "allow_votes", comment.allow_votes);
-            format_value(body, "author_rewards", comment.author_rewards);
-            format_value(body, "beneficiary_payout", comment.beneficiary_payout_value);
             format_value(body, "cashout_time", comment.cashout_time);
             format_value(body, "children", comment.children);
             format_value(body, "children_abs_rshares", comment.children_abs_rshares);
             format_value(body, "children_rshares2", comment.children_rshares2);
             format_value(body, "created", comment.created);
-            format_value(body, "curator_payout", comment.curator_payout_value);
             format_value(body, "depth", comment.depth);
             format_value(body, "last_payout", comment.last_payout);
             format_value(body, "max_accepted_payout", comment.max_accepted_payout);
@@ -93,7 +90,6 @@ namespace mongo_db {
             format_value(body, "parent_permlink", comment.parent_permlink);
             format_value(body, "percent_steem_dollars", comment.percent_steem_dollars);
             format_value(body, "reward_weight", comment.reward_weight);
-            format_value(body, "total_payout", comment.total_payout_value);
             format_value(body, "total_vote_weight", comment.total_vote_weight);
             format_value(body, "vote_rshares", comment.vote_rshares);
 
@@ -142,6 +138,22 @@ namespace mongo_db {
                 if (clu_itr != clu_idx.end()) {
                     format_value(body, "active", clu_itr->active);
                     format_value(body, "last_update", clu_itr->last_update);
+                }
+            }
+
+            if (db_.has_index<golos::plugins::social_network::comment_reward_index>()) {
+                const auto& cr_idx = db_.get_index<golos::plugins::social_network::comment_reward_index>().indices().get<golos::plugins::social_network::by_comment>();
+                auto cr_itr = cr_idx.find(comment.id);
+                if (cr_itr != cr_idx.end()) {
+                    format_value(body, "author_rewards", cr_itr->author_rewards);
+                    format_value(body, "author_gbg_payout", cr_itr->author_gbg_payout_value);
+                    format_value(body, "author_golos_payout", cr_itr->author_golos_payout_value);
+                    format_value(body, "author_gests_payout", cr_itr->author_gests_payout_value);
+                    format_value(body, "beneficiary_payout", cr_itr->beneficiary_payout_value);
+                    format_value(body, "beneficiary_gests_payout", cr_itr->beneficiary_gests_payout_value);
+                    format_value(body, "curator_payout", cr_itr->curator_payout_value);
+                    format_value(body, "curator_gests_payout", cr_itr->curator_gests_payout_value);
+                    format_value(body, "total_payout", cr_itr->total_payout_value);
                 }
             }
 

--- a/plugins/social_network/include/golos/plugins/social_network/social_network_types.hpp
+++ b/plugins/social_network/include/golos/plugins/social_network/social_network_types.hpp
@@ -9,7 +9,8 @@ namespace golos { namespace plugins { namespace social_network {
 
     enum social_network_types {
         comment_content_object_type = (SOCIAL_NETWORK_SPACE_ID << 8),
-        comment_last_update_object_type = (SOCIAL_NETWORK_SPACE_ID << 8) + 1
+        comment_last_update_object_type = (SOCIAL_NETWORK_SPACE_ID << 8) + 1,
+        comment_reward_object_type = (SOCIAL_NETWORK_SPACE_ID << 8) + 2
     };
 
 
@@ -100,6 +101,39 @@ namespace golos { namespace plugins { namespace social_network {
         >,
         allocator<comment_last_update_object>
     >;
+
+    class comment_reward_object: public object<comment_reward_object_type, comment_reward_object> {
+    public:
+        comment_reward_object() = delete;
+
+        template<typename Constructor, typename Allocator>
+        comment_reward_object(Constructor&& c, allocator<Allocator> a) {
+            c(*this);
+        }
+
+        id_type id;
+
+        comment_id_type comment;
+        asset total_payout_value{0, SBD_SYMBOL};
+        share_type author_rewards = 0;
+        asset author_gbg_payout_value{0, SBD_SYMBOL};
+        asset author_golos_payout_value{0, STEEM_SYMBOL};
+        asset author_gests_payout_value{0, VESTS_SYMBOL};
+        asset beneficiary_payout_value{0, SBD_SYMBOL};
+        asset beneficiary_gests_payout_value{0, VESTS_SYMBOL};
+        asset curator_payout_value{0, SBD_SYMBOL};
+        asset curator_gests_payout_value{0, VESTS_SYMBOL};
+    };
+
+    typedef object_id<comment_reward_object> comment_reward_id_type;
+
+    typedef multi_index_container<
+        comment_reward_object,
+        indexed_by<
+            ordered_unique<tag<by_id>, member<comment_reward_object, comment_reward_object::id_type, &comment_reward_object::id>>,
+            ordered_unique<tag<by_comment>, member<comment_reward_object, comment_object::id_type, &comment_reward_object::comment>>>,
+        allocator<comment_reward_object>
+    > comment_reward_index;
 } } }
 
 
@@ -111,3 +145,7 @@ CHAINBASE_SET_INDEX_TYPE(
 CHAINBASE_SET_INDEX_TYPE(
     golos::plugins::social_network::comment_last_update_object,
     golos::plugins::social_network::comment_last_update_index)
+
+CHAINBASE_SET_INDEX_TYPE(
+    golos::plugins::social_network::comment_reward_object,
+    golos::plugins::social_network::comment_reward_index)

--- a/tests/common/comment_reward.hpp
+++ b/tests/common/comment_reward.hpp
@@ -151,7 +151,7 @@ namespace golos { namespace chain {
         }
 
         asset total_payout() const {
-            return total_payout_;
+            return sbd_payout_ + db_.to_sbd(vesting_payout_ * db_.get_dynamic_global_properties().get_vesting_share_price());
         }
 
     private:
@@ -218,7 +218,6 @@ namespace golos { namespace chain {
             auto sbd_payout_value = comment_rewards_ / 2;
             auto vesting_payout_value = comment_rewards_ - sbd_payout_value;
 
-            total_payout_ = db_.to_sbd(asset(sbd_payout_value + vesting_payout_value, STEEM_SYMBOL));
             sbd_payout_ = asset(sbd_payout_value, SBD_SYMBOL);
             vesting_payout_ = fund_.create_vesting(asset(vesting_payout_value, STEEM_SYMBOL));
         }
@@ -240,7 +239,6 @@ namespace golos { namespace chain {
 
         asset sbd_payout_;
         asset vesting_payout_;
-        asset total_payout_;
     };
 
 } } // namespace golos::chain

--- a/tests/common/helpers.hpp
+++ b/tests/common/helpers.hpp
@@ -39,6 +39,10 @@
     BOOST_CHECK_EQUAL(posting_auths, POSTING);                     \
 }
 
+// Check if 2 numeric values are approximately equal
+#define APPROX_CHECK_EQUAL(X, Y, DELTA) {                          \
+    BOOST_CHECK(std::abs(X - Y) <= DELTA);                         \
+}
 
 // internals
 //-------------------------------------------------------------


### PR DESCRIPTION
#829 

**Checklist for comment rewards storing (Mongo-checking):**

1. In libraries/protocol/include/golos/protocol/config.hpp file,
temporarily set STEEMIT_CASHOUT_WINDOW_SECONDS to (2*60)
i.e. 2 minutes.

2. Don't do anything in config.

3. Run following script:

```
./cli_wallet --server-rpc-endpoint=ws://127.0.0.1:8091
set_password qwer
unlock qwer
import_key 5JVFFWRLwz6JoP9kguuRFfytToGU6cLgBVTL9t6NB3D3BQLbUBS
create_account cyberfounder test "{}" "30.000 GOLOS" true
transfer_to_vesting cyberfounder test "30.000 GOLOS" true
post_comment  test test "" test hello world "{}" true

create_account cyberfounder testg "{}" "30.000 GOLOS" true
transfer_to_vesting cyberfounder testg "30.000 GOLOS" true
vote testg test test 10 true

publish_feed cyberfounder {"base": "1.000 GBG", "quote": "10.000 GOLOS"} true
```

Result: after 2 minutes Mongo comment_object will have reward fields:

- author_rewards
- author_gbg_payout
- author_golos_payout
- author_gests_payout
- beneficiary_payout
- beneficiary_gests_payout
- curator_payout
- curator_gests_payout
- total_payout

4. In config.ini set
store-comment-rewards = false

And run same script.

Result: after 2 minutes Mongo comment_object won't have reward fields.

**Checklist for set_pending_payout, and API-checking checklist for comment rewards storing:**

1. In libraries/protocol/include/golos/protocol/config.hpp file,
temporarily set STEEMIT_CASHOUT_WINDOW_SECONDS to (2*60)
i.e. 2 minutes.

2. Ensure if config.ini haven't disabled store-comment-rewards.

3. In libraries/api/discussion_helper.cpp file,
temporarily change such line:
`r2 *= pot.amount.value;`
to:
`r2 *= 16152;
`
4. In libraries/chain/database.cpp file,
in claim_rshare_reward (which is called from comment cashout helper),
temporarily change such line:
`u256 rf(props.total_reward_fund_steem.amount.value);`
to
`u256 rf(16152);
`
5. Run above cli_wallet script.

6. In browser open following HTML file:
```
<script src="node_modules/golos-js/dist/golos.min.js"></script>
<script>
golos.config.set('websocket', 'ws://127.0.0.1:8091');
var logger = function(err, result) { console.log(err, result); };
 
var pen = "0.000 GBG";
var prev_row = '';
 
function gc_callback(err, result) {
  var test1 = document.getElementById("test1");
  var row = '';
  if (result["pending_payout_value"] == "0.000 GBG" && pen != "0.000 GBG") {
    row = '<td>FIN</td><td>' + result["author_gbg_payout_value"] + '</td><td>'
      + result["author_golos_payout_value"] + '</td><td>' + result["author_gests_payout_value"] + '</td><td>'
      + result["author_rewards"] + '</td><td>' + result['beneficiary_payout_value'] + '</td><td>' + result['beneficiary_gests_payout_value'] + '</td><td>'
      + result['curator_payout_value'] + '</td><td>' + result['curator_gests_payout_value'] + '</td>'
      + '<td>' + result['total_payout_value'] + '</td>';
    test1.innerHTML += row; window.scrollTo(0, document.body.scrollHeight);
  } else {
    row = '<td>PEND</td><td>' + result["pending_author_payout_gbg_value"] + '</td><td>'
      + result["pending_author_payout_golos_value"] + '</td><td>' + result["pending_author_payout_gests_value"] + '</td><td>'
      + '-' + '</td><td>-</td><td>' + result['pending_benefactor_payout_gests_value'] + '</td><td>'
      + '-' + '</td><td>' + result['pending_curator_payout_gests_value'] + '</td>'
      + '<td>' + result['pending_payout_value'] + '</td>';
    if (row != prev_row) {
      test1.innerHTML += row; window.scrollTo(0, document.body.scrollHeight);
      prev_row = row;
    }
    pen = result["pending_payout_value"];
    setTimeout(function() { golos.api.getContent('test', 'test', 10000, gc_callback); }, 1);
  }
}
 
golos.api.getContent('test', 'test', 10000, gc_callback);
</script>
<table border="1"><thead>
<th>status</th><th>author_gbg</th><th>author_golos</th><th>author_gests</th>
<th>a_r</th><th>benef_gbg</th><th>benef_gests</th>
<th>curator_gbg</th><th>curator_gests</th><th>total_gbg</th>
</thead><tbody id="test1">
Here it'll be, wait please
</tbody>
</table>
```

Result: after 2 min in browser will appear the row with status=FIN with values which should be approximately equal to status=PEND row which prepends FIN one.
For instance: total_gbg (FIN) = 1.612 GBG, total_gbg (PEND) = 1.613 GBG,
Difference should be less than 0.010 GBG. Usually it is 0.001 or 0.002 GBG.

7. Do same, but with 
store-comment-rewards = false
in config.ini.

Result: all PEND-rows are writing, but FIN-row has zero values.

**After checklists, don't forgot to undo all temporarily changes.**