### PR TITLE
Added annotated_signed_block #936

### DIFF
--- a/libraries/api/CMakeLists.txt
+++ b/libraries/api/CMakeLists.txt
@@ -9,6 +9,7 @@ list(APPEND CURRENT_TARGET_HEADERS
     include/golos/api/vote_state.hpp
     include/golos/api/account_vote.hpp
     include/golos/api/discussion_helper.hpp
+    include/golos/api/block_objects.hpp
 )
 
 list(APPEND CURRENT_TARGET_SOURCES
@@ -16,6 +17,7 @@ list(APPEND CURRENT_TARGET_SOURCES
     discussion_helper.cpp
     chain_api_properties.cpp
     witness_api_object.cpp
+    block_objects.cpp
 )
 
 if(BUILD_SHARED_LIBRARIES)

--- a/libraries/api/block_objects.cpp
+++ b/libraries/api/block_objects.cpp
@@ -1,0 +1,24 @@
+#include <golos/api/block_objects.hpp>
+
+namespace golos { namespace api {
+
+block_operation::block_operation() = default;
+
+annotated_signed_block::annotated_signed_block() = default;
+
+annotated_signed_block::annotated_signed_block(const signed_block& block)
+        : signed_block(block) {
+    block_id = id();
+    signing_key = signee();
+    transaction_ids.reserve(transactions.size());
+    for (const signed_transaction& tx : transactions) {
+        transaction_ids.push_back(tx.id());
+    }
+}
+
+annotated_signed_block::annotated_signed_block(const signed_block& block, const block_operations& ops)
+        : annotated_signed_block(block) {
+    _virtual_operations = ops;
+}
+
+} } // golos::api

--- a/libraries/api/include/golos/api/block_objects.hpp
+++ b/libraries/api/include/golos/api/block_objects.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <golos/chain/account_object.hpp>
+#include <golos/chain/database.hpp>
+#include <golos/chain/operation_notification.hpp>
+#include <golos/chain/steem_object_types.hpp>
+#include <golos/protocol/types.hpp>
+
+namespace golos { namespace api {
+
+using namespace golos::protocol;
+using golos::chain::operation_notification;
+
+// block_operation used in block_applied_callback to represent virtual operations.
+// default operation type have no position info (trx, op_in_trx)
+struct block_operation {
+
+    block_operation();
+
+    block_operation(const operation_notification& o) :
+        trx_in_block(o.trx_in_block),
+        op_in_trx(o.op_in_trx),
+        virtual_op(o.virtual_op),
+        op(o.op) {};
+
+    uint32_t trx_in_block = 0;
+    uint16_t op_in_trx = 0;
+    uint32_t virtual_op = 0;
+    operation op;
+};
+
+using block_operations = std::vector<block_operation>;
+
+struct annotated_signed_block : public signed_block {
+
+    annotated_signed_block();
+
+    annotated_signed_block(const signed_block& block);
+
+    annotated_signed_block(const signed_block& block, const block_operations& ops);
+
+    annotated_signed_block(const annotated_signed_block& block) = default;
+
+    block_id_type block_id;
+    public_key_type signing_key;
+    vector<transaction_id_type> transaction_ids;
+
+    // name field starting with _ coz it's not directly related to block
+    optional<block_operations> _virtual_operations;
+};
+
+} } // golos::api
+
+
+FC_REFLECT((golos::api::block_operation),
+    (trx_in_block)(op_in_trx)(virtual_op)(op))
+FC_REFLECT_DERIVED((golos::api::annotated_signed_block), ((golos::chain::signed_block)),
+    (block_id)(signing_key)(transaction_ids)(_virtual_operations))

--- a/libraries/wallet/include/golos/wallet/remote_node_api.hpp
+++ b/libraries/wallet/include/golos/wallet/remote_node_api.hpp
@@ -17,6 +17,7 @@
 
 #include <golos/api/account_api_object.hpp>
 #include <golos/api/account_vote.hpp>
+#include <golos/api/block_objects.hpp>
 #include <golos/api/discussion.hpp>
 #include <golos/api/vote_state.hpp>
 
@@ -46,7 +47,7 @@ using namespace golos::api;
  * Class is used by wallet to send formatted API calls to database_api plugin on remote node.
  */
 struct remote_database_api {
-    optional< database_api::signed_block > get_block( uint32_t );
+    optional< golos::api::annotated_signed_block > get_block( uint32_t );
     optional< block_header > get_block_header( uint32_t );
     fc::variant_object get_config();
     database_api::dynamic_global_property_object get_dynamic_global_properties();

--- a/libraries/wallet/include/golos/wallet/wallet.hpp
+++ b/libraries/wallet/include/golos/wallet/wallet.hpp
@@ -115,15 +115,6 @@ namespace golos { namespace wallet {
             string                    ws_server = "ws://localhost:8091";
         };
 
-        struct signed_block_with_info: public signed_block {
-            signed_block_with_info(const signed_block& block);
-            signed_block_with_info(const signed_block_with_info& block) = default;
-
-            block_id_type block_id;
-            public_key_type signing_key;
-            vector<transaction_id_type> transaction_ids;
-        };
-
         struct key_with_data {
             std::string account;
             std::string type;
@@ -262,7 +253,7 @@ namespace golos { namespace wallet {
              *
              * @returns Public block data on the blockchain
              */
-            optional<signed_block_with_info> get_block(uint32_t num);
+            optional<golos::api::annotated_signed_block> get_block(uint32_t num);
 
             /** Returns sequence of operations included/generated in a specified block
              *
@@ -1344,9 +1335,6 @@ namespace golos { namespace wallet {
     } }
 
 FC_REFLECT((golos::wallet::wallet_data), (cipher_keys)(ws_server))
-
-FC_REFLECT_DERIVED((golos::wallet::signed_block_with_info), ((golos::chain::signed_block)),
-        (block_id)(signing_key)(transaction_ids))
 
 FC_REFLECT( (golos::wallet::brain_key_info), (brain_priv_key)(wif_priv_key) (pub_key))
 

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -1262,7 +1262,7 @@ namespace golos { namespace wallet {
             return my->copy_wallet_file(destination_filename);
         }
 
-        optional<signed_block_with_info> wallet_api::get_block(uint32_t num) {
+        optional<golos::api::annotated_signed_block> wallet_api::get_block(uint32_t num) {
             return my->_remote_database_api->get_block( num );
         }
 
@@ -1642,15 +1642,6 @@ fc::ecc::private_key wallet_api::derive_private_key(const std::string& prefix_st
             auto secret = fc::sha256::hash( seed.c_str(), seed.size() );
             auto priv = fc::ecc::private_key::regenerate( secret );
             return std::make_pair( public_key_type( priv.get_public_key() ), key_to_wif( priv ) );
-        }
-
-        signed_block_with_info::signed_block_with_info(const signed_block& block): signed_block(block) {
-            block_id = id();
-            signing_key = signee();
-            transaction_ids.reserve(transactions.size());
-            for (const signed_transaction& tx : transactions) {
-                transaction_ids.push_back(tx.id());
-            }
         }
 
         witness_api::feed_history_api_object wallet_api::get_feed_history()const {

--- a/plugins/operation_history/CMakeLists.txt
+++ b/plugins/operation_history/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries (
     graphene_time
     chainbase
     fc
+    golos::api
 )
 
 target_include_directories(golos_${CURRENT_TARGET}

--- a/plugins/operation_history/include/golos/plugins/operation_history/plugin.hpp
+++ b/plugins/operation_history/include/golos/plugins/operation_history/plugin.hpp
@@ -26,6 +26,7 @@
 #include <appbase/application.hpp>
 #include <golos/plugins/chain/plugin.hpp>
 
+#include <golos/api/block_objects.hpp>
 #include <golos/chain/database.hpp>
 #include <boost/program_options.hpp>
 
@@ -38,10 +39,15 @@
 namespace golos { namespace plugins { namespace operation_history {
     using namespace chain;
 
+    using golos::api::annotated_signed_block;
+    using golos::api::block_operation;
+    using golos::api::block_operations;
+
     using plugins::json_rpc::void_type;
     using plugins::json_rpc::msg_pack;
     using plugins::json_rpc::msg_pack_transfer;
 
+    DEFINE_API_ARGS(get_block_with_virtual_ops, msg_pack, annotated_signed_block)
     DEFINE_API_ARGS(get_ops_in_block, msg_pack, std::vector<applied_operation>)
     DEFINE_API_ARGS(get_transaction,  msg_pack, annotated_signed_transaction)
 
@@ -70,6 +76,8 @@ namespace golos { namespace plugins { namespace operation_history {
         void plugin_shutdown() override;
 
         DECLARE_API(
+            (get_block_with_virtual_ops)
+
             /**
              *  @brief Get sequence of operations included/generated within a particular block
              *  @param block_num Height of the block whose generated virtual operations should be returned


### PR DESCRIPTION
#936 

# Checklists

Use testnet.

### Check refactored cli_wallet's `get_block` (based on database_api's get_block):

Run following cli-wallet script (**note**: run it after block 4 applied):

```
./cli_wallet --server-rpc-endpoint=ws://127.0.0.1:8091
set_password qwer
unlock qwer
import_key 5JVFFWRLwz6JoP9kguuRFfytToGU6cLgBVTL9t6NB3D3BQLbUBS
get_block 4
```

Result:
```
{
  ...
  "timestamp": ...,
  ...
  "transactions": [{
      ...
      "expiration": ...,
      "operations": [[
          "pow2", ...
        ]
      ],
      "extensions": [],
      "signatures": [
        ...
      ]
    }
  ],
  "block_id": "0000000000000000000000000000000000000000",
  "signing_key": "GLS1111111111111111111111111111111114T1Anm",
  "transaction_ids": []
}
```

### Check new method `get_block_with_virtual_ops`

1. Run this HTML script in browser **before** block 80 applied (**note**: this is a block applying after all hardforks):

```
<script src="node_modules/golos-js/dist/golos.min.js"></script>
Hello world
<script>
golos.config.set('websocket', 'ws://127.0.0.1:8091');
golos.api.send("operation_history", {"method": "get_block_with_virtual_ops", "params":[80]},
    function (err, result) {
document.body.innerHTML += '<pre>' + JSON.stringify(result, null, 2) + "</pre>";
});
</script>
```
Result:
```
{
  "previous": "0000000000000000000000000000000000000000",
  "timestamp": "1970-01-01T00:00:00",
  "witness": "",
  "transaction_merkle_root": "0000000000000000000000000000000000000000",
  "extensions": [],
  "witness_signature": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
  "transactions": [],
  "block_id": "0000000000000000000000000000000000000000",
  "signing_key": "GLS1111111111111111111111111111111114T1Anm",
  "transaction_ids": []
}
```
2. Now wait for this block and run again. Result:
```
{
  ...
  "timestamp": "2018-08-28T03:35:57",
  ...
  "_virtual_operations": [
    {
      "trx_in_block": 65535,
      "op_in_trx": 0,
      "virtual_op": 1,
      "op": [
        "producer_reward",
        ...
      ]
    }
  ]
}
```

### Check refactored `set_block_applied_callback`

**After all hardforks applied**, run:

```
<script src="node_modules/golos-js/dist/golos.min.js"></script>
Hello world
<script>
golos.config.set('websocket', 'ws://127.0.0.1:8091');
golos.api.send("database_api", {"method": "set_block_applied_callback", "params":["full"]},
    function (err, result) {
document.body.innerHTML += '<pre>' + JSON.stringify(result, null, 2) + "</pre>";
});
</script>
```
Result:
```
{
  ...
  "timestamp": ...,
  ...
  "transaction_ids": [],
  "_virtual_operations": [
    {
      "trx_in_block": 65535,
      "op_in_trx": 0,
      "virtual_op": 1,
      "op": [
        "producer_reward",
        ...
      ]
    }
  ]
}
```