### PR TITLE
Store account reputation in transit state #1293

### DIFF
--- a/libraries/api/include/golos/api/account_api_object.hpp
+++ b/libraries/api/include/golos/api/account_api_object.hpp
@@ -99,7 +99,7 @@ struct account_api_object {
 
     set<string> witness_votes;
 
-    fc::optional<share_type> reputation;
+    share_type reputation;
 
     account_name_type referrer_account;
     uint16_t referrer_interest_rate = 0;

--- a/libraries/api/include/golos/api/discussion.hpp
+++ b/libraries/api/include/golos/api/discussion.hpp
@@ -31,7 +31,7 @@ namespace golos { namespace api {
         std::vector<vote_state> active_votes;
         uint32_t active_votes_count = 0;
         std::vector<string> replies; ///< author/slug mapping
-        fc::optional<share_type> author_reputation;
+        share_type author_reputation;
         fc::optional<asset> promoted;
         double hot = 0;
         double trending = 0;

--- a/libraries/api/include/golos/api/discussion_helper.hpp
+++ b/libraries/api/include/golos/api/discussion_helper.hpp
@@ -15,7 +15,6 @@ namespace golos { namespace api {
         discussion_helper() = delete;
         discussion_helper(
             golos::chain::database& db,
-            std::function<void(const golos::chain::database&, const account_name_type&, fc::optional<share_type>&)> fill_reputation,
             std::function<void(const golos::chain::database&, discussion&)> fill_promoted,
             std::function<void(const database&, const comment_object&, comment_api_object&)> fill_comment_info
         );

--- a/libraries/api/include/golos/api/vote_state.hpp
+++ b/libraries/api/include/golos/api/vote_state.hpp
@@ -9,7 +9,7 @@ namespace golos { namespace api {
         uint64_t weight = 0;
         int64_t rshares = 0;
         int16_t percent = 0;
-        fc::optional<share_type> reputation;
+        share_type reputation;
         time_point_sec time;
     };
 

--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -5065,4 +5065,40 @@ namespace golos { namespace chain {
                 }
             }
         }
+
+        share_type database::get_reputation(const account_name_type& account) const {
+            share_type res = 0;
+            auto reputation = get_account(account).reputation;
+            if (!!reputation) {
+                res = *reputation;
+            }
+            return res;
+        }
+
+        void database::update_reputation(const account_name_type& author, const account_name_type& voter, int64_t rshares, bool edit_vote) {
+            const auto& author_acc = get_account(author);
+
+            share_type author_rep = 0;
+            if (!!author_acc.reputation) {
+                author_rep = *author_acc.reputation;
+
+                if (edit_vote) {
+                    author_rep -= rshares;
+                }
+            }
+
+            const auto& voter_rep = get_reputation(voter);
+
+            // Rule #1: Must have non-negative reputation to effect another user's reputation
+            if (voter_rep > 0) {
+                // Rule #2: If you are down voting another user, you must have more reputation than them to impact their reputation
+                if (rshares >= 0 || voter_rep > author_rep) {
+                    author_rep += rshares;
+                }
+            }
+
+            modify(author_acc, [&](account_object& a) {
+                a.reputation = author_rep;
+            });
+        }
 } } //golos::chain

--- a/libraries/chain/include/golos/chain/account_object.hpp
+++ b/libraries/chain/include/golos/chain/account_object.hpp
@@ -112,6 +112,8 @@ public:
     time_point_sec referral_end_date = time_point_sec::min();
     asset referral_break_fee = asset(0, STEEM_SYMBOL);
 
+    optional<share_type> reputation;
+
     /// This function should be used only when the account votes for a witness directly
     share_type witness_vote_weight() const {
         return std::accumulate(proxied_vsf_votes.begin(),
@@ -523,7 +525,7 @@ FC_REFLECT((golos::chain::account_object),
     (posting_rewards)
     (proxied_vsf_votes)(witnesses_voted_for)
     (last_post)
-    (referrer_account)(referrer_interest_rate)(referral_end_date)(referral_break_fee)
+    (referrer_account)(referrer_interest_rate)(referral_end_date)(referral_break_fee)(reputation)
 )
 CHAINBASE_SET_INDEX_TYPE(golos::chain::account_object, golos::chain::account_index)
 

--- a/libraries/chain/include/golos/chain/database.hpp
+++ b/libraries/chain/include/golos/chain/database.hpp
@@ -463,6 +463,9 @@ namespace golos { namespace chain {
 
             void pay_liquidity_reward();
 
+            share_type get_reputation(const account_name_type& account) const;
+            void update_reputation(const account_name_type& author, const account_name_type& voter, int64_t rshares, bool edit_vote);
+
             /**
              * Helper method to return the current sbd value of a given amount of
              * STEEM.  Return 0 SBD if there isn't a current_median_history

--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -1668,6 +1668,8 @@ namespace golos { namespace chain {
                     });
 
                     _db.adjust_rshares2(comment, old_rshares, new_rshares);
+
+                    _db.update_reputation(o.author, o.voter, (rshares >> 6), false); // Shift away precision. It is noise
                 } else {
                     GOLOS_CHECK_LOGIC(itr->num_changes < STEEMIT_MAX_VOTE_CHANGES,
                             logic_exception::voter_has_used_maximum_vote_changes,
@@ -1775,6 +1777,8 @@ namespace golos { namespace chain {
                     });
 
                     _db.adjust_rshares2(comment, old_rshares, new_rshares);
+
+                    _db.update_reputation(o.author, o.voter, (rshares >> 6), true); // Shift away precision. It is noise
                 }
             } FC_CAPTURE_AND_RETHROW((o))
         }

--- a/plugins/database_api/CMakeLists.txt
+++ b/plugins/database_api/CMakeLists.txt
@@ -38,7 +38,6 @@ target_link_libraries(
         golos_${CURRENT_TARGET}
         golos_chain
         golos::chain_plugin
-        golos::follow
         golos_protocol
         golos::json_rpc
         graphene_utilities

--- a/plugins/database_api/api.cpp
+++ b/plugins/database_api/api.cpp
@@ -1,7 +1,6 @@
 #include <golos/plugins/database_api/plugin.hpp>
 #include <golos/plugins/json_rpc/plugin.hpp>
 #include <golos/plugins/json_rpc/api_helper.hpp>
-#include <golos/plugins/follow/plugin.hpp>
 #include <golos/protocol/get_config.hpp>
 #include <golos/protocol/exceptions.hpp>
 #include <golos/chain/operation_notification.hpp>
@@ -361,7 +360,7 @@ std::vector<account_api_object> plugin::api_impl::get_accounts(std::vector<std::
         auto itr = idx.find(name);
         if (itr != idx.end()) {
             results.push_back(account_api_object(*itr, _db));
-            follow::fill_account_reputation(_db, itr->name, results.back().reputation);
+            results.back().reputation = _db.get_reputation(itr->name);
             auto vitr = vidx.lower_bound(boost::make_tuple(itr->id, witness_id_type()));
             while (vitr != vidx.end() && vitr->account == itr->id) {
                 results.back().witness_votes.insert(_db.get(vitr->witness).owner);

--- a/plugins/follow/include/golos/plugins/follow/follow_api_object.hpp
+++ b/plugins/follow/include/golos/plugins/follow/follow_api_object.hpp
@@ -52,7 +52,7 @@ namespace golos {
 
             struct account_reputation {
                 std::string account;
-                fc::optional<golos::protocol::share_type> reputation;
+                golos::protocol::share_type reputation;
             };
 
             struct follow_api_object {

--- a/plugins/follow/include/golos/plugins/follow/follow_objects.hpp
+++ b/plugins/follow/include/golos/plugins/follow/follow_objects.hpp
@@ -25,10 +25,9 @@ namespace golos {
             enum follow_plugin_object_type {
                 follow_object_type = (FOLLOW_SPACE_ID << 8),
                 feed_object_type = (FOLLOW_SPACE_ID << 8) + 1,
-                reputation_object_type = (FOLLOW_SPACE_ID << 8) + 2,
-                blog_object_type = (FOLLOW_SPACE_ID << 8) + 3,
-                follow_count_object_type = (FOLLOW_SPACE_ID << 8) + 4,
-                blog_author_stats_object_type = (FOLLOW_SPACE_ID << 8) + 5
+                blog_object_type = (FOLLOW_SPACE_ID << 8) + 2,
+                follow_count_object_type = (FOLLOW_SPACE_ID << 8) + 3,
+                blog_author_stats_object_type = (FOLLOW_SPACE_ID << 8) + 4
             };
 
 
@@ -117,22 +116,6 @@ namespace golos {
             };
 
             typedef object_id<blog_author_stats_object> blog_author_stats_id_type;
-
-
-            class reputation_object : public object<reputation_object_type, reputation_object> {
-            public:
-                template<typename Constructor, typename Allocator>
-                reputation_object(Constructor &&c, allocator<Allocator> a) {
-                    c(*this);
-                }
-
-                id_type id;
-
-                account_name_type account;
-                share_type reputation;
-            };
-
-            typedef object_id<reputation_object> reputation_id_type;
 
 
             class follow_count_object : public object<follow_count_object_type, follow_count_object> {
@@ -224,19 +207,6 @@ namespace golos {
                                     composite_key_compare<std::less<comment_object::id_type>,
                                             std::less<account_name_type>>> >, allocator<blog_object> > blog_index;
 
-            struct by_reputation;
-
-            typedef multi_index_container<reputation_object, indexed_by<
-                    ordered_unique<tag<by_id>, member<reputation_object, reputation_id_type, &reputation_object::id>>,
-                    ordered_unique<tag<by_reputation>, composite_key<reputation_object,
-                            member<reputation_object, share_type, &reputation_object::reputation>,
-                            member<reputation_object, account_name_type, &reputation_object::account> >,
-                            composite_key_compare<std::greater<share_type>, std::less<account_name_type>>>,
-                    ordered_unique<tag<by_account>,
-                            member<reputation_object, account_name_type, &reputation_object::account>>>,
-                    allocator<reputation_object> > reputation_index;
-
-
             struct by_followers;
             struct by_following;
 
@@ -269,9 +239,6 @@ CHAINBASE_SET_INDEX_TYPE(golos::plugins::follow::feed_object, golos::plugins::fo
 
 FC_REFLECT((golos::plugins::follow::blog_object), (id)(account)(comment)(reblogged_on)(blog_feed_id))
 CHAINBASE_SET_INDEX_TYPE(golos::plugins::follow::blog_object, golos::plugins::follow::blog_index)
-
-FC_REFLECT((golos::plugins::follow::reputation_object), (id)(account)(reputation))
-CHAINBASE_SET_INDEX_TYPE(golos::plugins::follow::reputation_object, golos::plugins::follow::reputation_index)
 
 FC_REFLECT((golos::plugins::follow::follow_count_object), (id)(account)(follower_count)(following_count))
 CHAINBASE_SET_INDEX_TYPE(golos::plugins::follow::follow_count_object, golos::plugins::follow::follow_count_index)

--- a/plugins/follow/include/golos/plugins/follow/plugin.hpp
+++ b/plugins/follow/include/golos/plugins/follow/plugin.hpp
@@ -21,12 +21,6 @@ namespace golos { namespace plugins { namespace follow {
         };
     };
 
-    void fill_account_reputation(
-        const golos::chain::database& db,
-        const account_name_type& account,
-        fc::optional<share_type>& reputation
-    );
-
     ///               API,                          args,       return
     DEFINE_API_ARGS(get_followers,           msg_pack, std::vector<follow_api_object>)
     DEFINE_API_ARGS(get_following,           msg_pack, std::vector<follow_api_object>)

--- a/plugins/social_network/CMakeLists.txt
+++ b/plugins/social_network/CMakeLists.txt
@@ -29,7 +29,6 @@ target_link_libraries(
         golos_chain
         golos::chain_plugin
         golos::network
-        golos::follow
         golos::tags
         appbase
 )

--- a/plugins/social_network/include/golos/plugins/social_network/social_network.hpp
+++ b/plugins/social_network/include/golos/plugins/social_network/social_network.hpp
@@ -3,7 +3,6 @@
 #include <appbase/application.hpp>
 #include <golos/plugins/chain/plugin.hpp>
 #include <golos/api/discussion.hpp>
-#include <golos/plugins/follow/plugin.hpp>
 #include <golos/api/account_vote.hpp>
 #include <golos/api/vote_state.hpp>
 #include <golos/api/discussion_helper.hpp>

--- a/plugins/social_network/social_network.cpp
+++ b/plugins/social_network/social_network.cpp
@@ -85,7 +85,7 @@ namespace golos { namespace plugins { namespace social_network {
 
     struct social_network::impl final {
         impl(): db(appbase::app().get_plugin<chain::plugin>().db()) {
-            helper = std::make_unique<discussion_helper>(db, follow::fill_account_reputation, fill_promoted, fill_comment_info);
+            helper = std::make_unique<discussion_helper>(db, fill_promoted, fill_comment_info);
         }
 
         ~impl() = default;

--- a/plugins/tags/plugin.cpp
+++ b/plugins/tags/plugin.cpp
@@ -25,7 +25,6 @@ namespace golos { namespace plugins { namespace tags {
         impl(): database_(appbase::app().get_plugin<chain::plugin>().db()) {
             helper = std::make_unique<discussion_helper>(
                 database_,
-                follow::fill_account_reputation,
                 fill_promoted,
                 social_network::fill_comment_info);
         }


### PR DESCRIPTION
Resolves #1293

Account now has `reputation` field which will be serialize in state with other account fields.
Running follow-plugin is not required now.