### PR TITLE
Add account metadata to operation dump #1292

### DIFF
--- a/plugins/operation_dump/include/golos/plugins/operation_dump/operation_dump_visitor.hpp
+++ b/plugins/operation_dump/include/golos/plugins/operation_dump/operation_dump_visitor.hpp
@@ -181,6 +181,35 @@ public:
 
         fc::raw::pack(b, op.account);
     }
+
+    // TODO: Remove mandatory hash from header to save 8 bytes on each record
+    auto operator()(const account_create_operation& op) -> result_type {
+        auto& b = write_op_header("account_metas", 0);
+
+        fc::raw::pack(b, op.new_account_name);
+        fc::raw::pack(b, op.json_metadata);
+    }
+
+    auto operator()(const account_create_with_delegation_operation& op) -> result_type {
+        auto& b = write_op_header("account_metas", 0);
+
+        fc::raw::pack(b, op.new_account_name);
+        fc::raw::pack(b, op.json_metadata);
+    }
+
+    auto operator()(const account_update_operation& op) -> result_type {
+        auto& b = write_op_header("account_metas", 0);
+
+        fc::raw::pack(b, op.account);
+        fc::raw::pack(b, op.json_metadata);
+    }
+
+    auto operator()(const account_metadata_operation& op) -> result_type {
+        auto& b = write_op_header("account_metas", 0);
+
+        fc::raw::pack(b, op.account);
+        fc::raw::pack(b, op.json_metadata);
+    }
 };
 
 } } } // golos::plugins::operation_dump

--- a/plugins/operation_dump/include/golos/plugins/operation_dump/operation_dump_visitor.hpp
+++ b/plugins/operation_dump/include/golos/plugins/operation_dump/operation_dump_visitor.hpp
@@ -198,6 +198,10 @@ public:
     }
 
     auto operator()(const account_update_operation& op) -> result_type {
+        if (op.json_metadata.size() == 0) {
+            return;
+        }
+
         auto& b = write_op_header("account_metas", 0);
 
         fc::raw::pack(b, op.account);


### PR DESCRIPTION
Resolves #1292

Do not requires enabled storing of account metadata.