### PR TITLE
Serialized state: add comment data & remove non-consensus #1302 #1172

### DIFF
--- a/plugins/chain/serialize_state.hpp
+++ b/plugins/chain/serialize_state.hpp
@@ -11,6 +11,7 @@ namespace golos { namespace chain {
     using account_name_type = fc::fixed_string<fc::uint128_t>;
     struct shared_authority;
     class comment_object;
+    class savings_withdraw_object;
 }}
 namespace golos { namespace protocol {
     struct beneficiary_route_type;
@@ -20,6 +21,7 @@ namespace golos { namespace protocol {
 namespace fc { namespace raw {
 
 template<typename S> void pack(S&, const golos::chain::comment_object&);
+template<typename S> void pack(S&, const golos::chain::savings_withdraw_object&);
 template<typename S> void pack(S&, const golos::chain::account_name_type&);
 template<typename S> void pack(S&, const golos::chain::shared_authority&);
 template<typename S> void pack(S&, const golos::protocol::beneficiary_route_type&);


### PR DESCRIPTION
Note: this PR changes serialized state format and introduces v2.

+ store block number in serialized state header
+ store `depth` and `children` fields for closed posts #1302
+ don't store non-consensus votes #1172
+ don't store savings withdraw memo #1172
+ better custom packer for comment object (compact storage)
+ removed indexes which are not needed