### PR TITLE
Add wallet data to operation dumpp #1336

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -2318,7 +2318,7 @@ namespace golos { namespace chain {
                     }
                 }
 
-                push_virtual_operation(delegation_reward_operation(delegator.name, delegatee.name, dvir.payout_strategy, delegator_vesting));
+                push_virtual_operation(delegation_reward_operation(delegator.name, delegatee.name, dvir.payout_strategy, delegator_vesting, asset(delegator_claim, STEEM_SYMBOL)));
 
                 modify(delegator, [&](account_object& a) {
                     a.delegation_rewards += delegator_claim;
@@ -2337,7 +2337,7 @@ namespace golos { namespace chain {
 
             auto voter_reward = create_vesting(voter, asset(voter_claim, STEEM_SYMBOL));
 
-            push_virtual_operation(curation_reward_operation(voter.name, voter_reward, author, permlink));
+            push_virtual_operation(curation_reward_operation(voter.name, voter_reward, author, permlink, asset(voter_claim, STEEM_SYMBOL)));
 
             modify(voter, [&](account_object &a) {
                 a.curation_rewards += voter_claim;
@@ -2461,7 +2461,7 @@ namespace golos { namespace chain {
                         // stats only.. TODO: Move to plugin...
                         total_payout = to_sbd(asset(reward_tokens.to_uint64(), STEEM_SYMBOL));
 
-                        push_virtual_operation(author_reward_operation(comment.author, to_string(comment.permlink), sbd_payout.first, sbd_payout.second, vest_created));
+                        push_virtual_operation(author_reward_operation(comment.author, to_string(comment.permlink), sbd_payout.first, sbd_payout.second, vest_created, asset(sbd_steem, STEEM_SYMBOL), asset(vesting_steem, STEEM_SYMBOL)));
                         push_virtual_operation(comment_reward_operation(comment.author, to_string(comment.permlink), total_payout));
 
                         modify(get_account(comment.author), [&](account_object &a) {

--- a/libraries/protocol/include/golos/protocol/steem_virtual_operations.hpp
+++ b/libraries/protocol/include/golos/protocol/steem_virtual_operations.hpp
@@ -12,9 +12,9 @@ namespace golos { namespace protocol {
             author_reward_operation() {
             }
 
-            author_reward_operation(const account_name_type &a, const string &p, const asset &s, const asset &st, const asset &v)
+            author_reward_operation(const account_name_type &a, const string &p, const asset &s, const asset &st, const asset &v, const asset &sst, const asset &vg)
                     : author(a), permlink(p), sbd_payout(s), steem_payout(st),
-                      vesting_payout(v) {
+                      vesting_payout(v), sbd_and_steem_in_golos(sst), vesting_payout_in_golos(vg) {
             }
 
             account_name_type author;
@@ -22,6 +22,8 @@ namespace golos { namespace protocol {
             asset sbd_payout;
             asset steem_payout;
             asset vesting_payout;
+            asset sbd_and_steem_in_golos; // not reflected
+            asset vesting_payout_in_golos; // not reflected
         };
 
 
@@ -29,15 +31,16 @@ namespace golos { namespace protocol {
             curation_reward_operation() {
             }
 
-            curation_reward_operation(const string &c, const asset &r, const string &a, const string &p)
+            curation_reward_operation(const string &c, const asset &r, const string &a, const string &p, const asset &rg)
                     : curator(c), reward(r), comment_author(a),
-                      comment_permlink(p) {
+                      comment_permlink(p), reward_in_golos(rg) {
             }
 
             account_name_type curator;
             asset reward;
             account_name_type comment_author;
             string comment_permlink;
+            asset reward_in_golos; // not reflected
         };
 
         struct auction_window_reward_operation : public virtual_operation {
@@ -212,14 +215,15 @@ namespace golos { namespace protocol {
             delegation_reward_operation() {
             }
 
-            delegation_reward_operation(const account_name_type& dr, const account_name_type& de, const delegator_payout_strategy& ps, const asset& vs)
-                    : delegator(dr), delegatee(de), payout_strategy(ps), vesting_shares(vs) {
+            delegation_reward_operation(const account_name_type& dr, const account_name_type& de, const delegator_payout_strategy& ps, const asset& vs, const asset& vsg)
+                    : delegator(dr), delegatee(de), payout_strategy(ps), vesting_shares(vs), vesting_shares_in_golos(vsg) {
             }
 
             account_name_type delegator;
             account_name_type delegatee;
             delegator_payout_strategy payout_strategy;
             asset vesting_shares;
+            asset vesting_shares_in_golos; // not reflected
         };
 
         struct return_vesting_delegation_operation: public virtual_operation {

--- a/plugins/operation_dump/include/golos/plugins/operation_dump/operation_dump_visitor.hpp
+++ b/plugins/operation_dump/include/golos/plugins/operation_dump/operation_dump_visitor.hpp
@@ -84,34 +84,40 @@ public:
         write_op_header("delete_comments", COMMENT_ID(op));
     }
 
-    auto operator()(const comment_benefactor_reward_operation& op) -> result_type {
-        auto& b = write_op_header("benefactor_rewards", COMMENT_ID(op));
-
-        fc::raw::pack(b, op);
-    }
-
     auto operator()(const author_reward_operation& op) -> result_type {
         auto& b = write_op_header("author_rewards", COMMENT_ID(op));
 
-        fc::raw::pack(b, op);
+        fc::raw::pack(b, op.author);
+        fc::raw::pack(b, op.permlink);
+        fc::raw::pack(b, op.sbd_and_steem_in_golos);
+        fc::raw::pack(b, op.vesting_payout_in_golos);
+        fc::raw::pack(b, _block.timestamp);
     }
 
     auto operator()(const curation_reward_operation& op) -> result_type {
         auto& b = write_op_header("curation_rewards", std::string(op.comment_author) + "/" + op.comment_permlink);
 
-        fc::raw::pack(b, op);
-    }
-
-    auto operator()(const auction_window_reward_operation& op) -> result_type {
-        auto& b = write_op_header("auction_window_rewards", std::string(op.comment_author) + "/" + op.comment_permlink);
-
-        fc::raw::pack(b, op);
+        fc::raw::pack(b, op.curator);
+        fc::raw::pack(b, op.reward_in_golos);
+        fc::raw::pack(b, op.comment_author);
+        fc::raw::pack(b, op.comment_permlink);
+        fc::raw::pack(b, _block.timestamp);
     }
 
     auto operator()(const total_comment_reward_operation& op) -> result_type {
         auto& b = write_op_header("total_comment_rewards", COMMENT_ID(op));
 
         fc::raw::pack(b, op);
+    }
+
+    auto operator()(const delegation_reward_operation& op) -> result_type {
+        auto& b = write_op_header("delegation_rewards");
+
+        fc::raw::pack(b, op.delegator);
+        fc::raw::pack(b, op.delegatee);
+        fc::raw::pack(b, op.payout_strategy);
+        fc::raw::pack(b, op.vesting_shares_in_golos);
+        fc::raw::pack(b, _block.timestamp);
     }
 
     auto operator()(const vote_operation& op) -> result_type {


### PR DESCRIPTION
Resolves #1336 

Tolstoy wants rewards with GBG payouts in GBG, GOLOS payouts in GOLOS, and VESTS payout in GOLOS. But there is no GBG in Cyberway.

In this PR:

- GBG parts of payouts are stored in sum with GOLOS, VESTS stored as GOLOS. Just stored, not converted. Because conversions which complicate code and can decrease precision, just added non-reflected fields to virtual operations of rewards.
- Added block timestamps to reward operations.
- Useless virtual operations removed from operation dump.

This implementation fits to IO needs in best way.

Count limitations (30 day for transfers, 24 hours for rewards) will be introduced when converting this dump to EE-genesis, not here. Operation dump should be as full as possible because it takes long time to collect.