### PR TITLE
Add transfer_to_vesting operation dump #1336

### DIFF
--- a/plugins/operation_dump/include/golos/plugins/operation_dump/operation_dump_plugin.hpp
+++ b/plugins/operation_dump/include/golos/plugins/operation_dump/operation_dump_plugin.hpp
@@ -36,6 +36,7 @@ public:
     dump_buffers buffers;
     clarifications<int64_t> vote_rshares;
     clarifications<bool> not_deleted_comments;
+    clarifications<asset> transfer_golos_amounts;
 private:
     class operation_dump_plugin_impl;
 

--- a/plugins/operation_dump/include/golos/plugins/operation_dump/operation_dump_visitor.hpp
+++ b/plugins/operation_dump/include/golos/plugins/operation_dump/operation_dump_visitor.hpp
@@ -61,7 +61,7 @@ public:
 
         fc::raw::pack(b, op.from);
         fc::raw::pack(b, op.to);
-        fc::raw::pack(b, op.amount);
+        fc::raw::pack(b, pop_clarification(_plugin.transfer_golos_amounts));
         fc::raw::pack(b, op.memo);
         fc::raw::pack(b, false); // to vesting
         fc::raw::pack(b, _block.timestamp);

--- a/plugins/operation_dump/include/golos/plugins/operation_dump/operation_dump_visitor.hpp
+++ b/plugins/operation_dump/include/golos/plugins/operation_dump/operation_dump_visitor.hpp
@@ -59,7 +59,22 @@ public:
     auto operator()(const transfer_operation& op) -> result_type {
         auto& b = write_op_header("transfers");
 
-        fc::raw::pack(b, op);
+        fc::raw::pack(b, op.from);
+        fc::raw::pack(b, op.to);
+        fc::raw::pack(b, op.amount);
+        fc::raw::pack(b, op.memo);
+        fc::raw::pack(b, false); // to vesting
+        fc::raw::pack(b, _block.timestamp);
+    }
+
+    auto operator()(const transfer_to_vesting_operation& op) -> result_type {
+        auto& b = write_op_header("transfers");
+
+        fc::raw::pack(b, op.from);
+        fc::raw::pack(b, op.to);
+        fc::raw::pack(b, op.amount);
+        fc::raw::pack(b, ""); // memo
+        fc::raw::pack(b, true); // to vesting
         fc::raw::pack(b, _block.timestamp);
     }
 

--- a/plugins/operation_dump/operation_dump_plugin.cpp
+++ b/plugins/operation_dump/operation_dump_plugin.cpp
@@ -47,6 +47,12 @@ struct post_operation_clarifier {
 
         add_clarification(_plugin.not_deleted_comments, not_deleted);
     }
+
+    result_type operator()(const transfer_operation& op) const {
+        auto golos_amount = (op.amount.symbol == STEEM_SYMBOL) ? op.amount : _db.to_steem(op.amount);
+
+        add_clarification(_plugin.transfer_golos_amounts, golos_amount);
+    }
 };
 
 class operation_dump_plugin::operation_dump_plugin_impl final {
@@ -62,6 +68,7 @@ public:
         virtual_ops.erase(block_num);
         _plugin.vote_rshares.erase(block_num);
         _plugin.not_deleted_comments.erase(block_num);
+        _plugin.transfer_golos_amounts.erase(block_num);
     }
 
     void on_block(const signed_block& block) {


### PR DESCRIPTION
Resolves #1336

- Added `transfer_to_vesting_operation` to dump. Stored in same file with transfers because, logically, they are transfers, and IO wants them in single list.
- Found what `transfer_operation` writes to EE-genesis without conversion GBG to GOLOS. Added conversion.