### PR TITLE
Allow witnesses limit author promote rate #1062

### DIFF
--- a/libraries/api/chain_api_properties.cpp
+++ b/libraries/api/chain_api_properties.cpp
@@ -40,7 +40,8 @@ namespace golos { namespace api {
             worker_from_vesting_fund_percent = src.worker_from_vesting_fund_percent;
             worker_from_witness_fund_percent = src.worker_from_witness_fund_percent;
             worker_techspec_approve_term_sec = src.worker_techspec_approve_term_sec;
-            worker_result_approve_term_sec = src.worker_result_approve_term_sec;
+            min_vote_author_promote_rate = src.min_vote_author_promote_rate;
+            max_vote_author_promote_rate = src.max_vote_author_promote_rate;
         }
     }
 

--- a/libraries/api/include/golos/api/chain_api_properties.hpp
+++ b/libraries/api/include/golos/api/chain_api_properties.hpp
@@ -52,6 +52,9 @@ namespace golos { namespace api {
         fc::optional<uint16_t> worker_from_witness_fund_percent;
         fc::optional<uint32_t> worker_techspec_approve_term_sec;
         fc::optional<uint32_t> worker_result_approve_term_sec;
+
+        fc::optional<uint16_t> min_vote_author_promote_rate;
+        fc::optional<uint16_t> max_vote_author_promote_rate;
     };
 
 } } // golos::api
@@ -67,4 +70,5 @@ FC_REFLECT(
     (min_curation_percent)(max_curation_percent)(curation_reward_curve)
     (allow_distribute_auction_reward)(allow_return_auction_reward_to_fund)
     (worker_from_content_fund_percent)(worker_from_vesting_fund_percent)(worker_from_witness_fund_percent)
-    (worker_techspec_approve_term_sec)(worker_result_approve_term_sec))
+    (worker_techspec_approve_term_sec)(worker_result_approve_term_sec)
+    (min_vote_author_promote_rate)(max_vote_author_promote_rate))

--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -1939,6 +1939,7 @@ namespace golos { namespace chain {
             calc_median(&chain_properties_21::worker_from_witness_fund_percent);
             calc_median(&chain_properties_21::worker_techspec_approve_term_sec);
             calc_median(&chain_properties_21::worker_result_approve_term_sec);
+            calc_median_min_max(&chain_properties_21::min_vote_author_promote_rate, &chain_properties_21::max_vote_author_promote_rate);
 
             const auto& dynamic_global_properties = get_dynamic_global_properties();
 

--- a/libraries/protocol/include/golos/protocol/steem_operations.hpp
+++ b/libraries/protocol/include/golos/protocol/steem_operations.hpp
@@ -723,6 +723,16 @@ namespace golos { namespace protocol {
              */
             uint32_t worker_result_approve_term_sec = GOLOS_WORKER_RESULT_APPROVE_TERM_SEC;
 
+            /**
+             * Minimum rate of curator payment to be sent to author for promoting him by curator
+             */
+            uint16_t min_vote_author_promote_rate = GOLOS_MIN_VOTE_AUTHOR_PROMOTE_RATE;
+
+            /**
+             * Maximum rate of curator payment to be sent to author for promoting him by curator
+             */
+            uint16_t max_vote_author_promote_rate = GOLOS_MAX_VOTE_AUTHOR_PROMOTE_RATE;
+
             void validate() const;
 
             chain_properties_21& operator=(const chain_properties_17& src) {
@@ -1466,7 +1476,8 @@ FC_REFLECT_DERIVED(
 FC_REFLECT_DERIVED(
     (golos::protocol::chain_properties_21), ((golos::protocol::chain_properties_19)),
     (worker_from_content_fund_percent)(worker_from_vesting_fund_percent)(worker_from_witness_fund_percent)
-    (worker_techspec_approve_term_sec)(worker_result_approve_term_sec))
+    (worker_techspec_approve_term_sec)(worker_result_approve_term_sec)
+    (min_vote_author_promote_rate)(max_vote_author_promote_rate))
 
 FC_REFLECT_TYPENAME((golos::protocol::versioned_chain_properties))
 

--- a/libraries/protocol/steem_operations.cpp
+++ b/libraries/protocol/steem_operations.cpp
@@ -351,6 +351,8 @@ namespace golos { namespace protocol {
             GOLOS_CHECK_VALUE_LE(worker_from_witness_fund_percent, STEEMIT_100_PERCENT);
             GOLOS_CHECK_VALUE_LE(worker_techspec_approve_term_sec, GOLOS_WORKER_TECHSPEC_APPROVE_TERM_SEC);
             GOLOS_CHECK_VALUE_LE(worker_result_approve_term_sec, GOLOS_WORKER_RESULT_APPROVE_TERM_SEC);
+            GOLOS_CHECK_VALUE_LEGE(min_vote_author_promote_rate, GOLOS_MIN_VOTE_AUTHOR_PROMOTE_RATE, max_vote_author_promote_rate);
+            GOLOS_CHECK_VALUE_LEGE(max_vote_author_promote_rate, min_vote_author_promote_rate, GOLOS_MAX_VOTE_AUTHOR_PROMOTE_RATE);
         }
 
         void witness_update_operation::validate() const {

--- a/libraries/wallet/include/golos/wallet/wallet.hpp
+++ b/libraries/wallet/include/golos/wallet/wallet.hpp
@@ -77,6 +77,9 @@ namespace golos { namespace wallet {
             fc::optional<uint16_t> worker_from_witness_fund_percent;
             fc::optional<uint32_t> worker_techspec_approve_term_sec;
             fc::optional<uint32_t> worker_result_approve_term_sec;
+
+            fc::optional<uint16_t> min_vote_author_promote_rate;
+            fc::optional<uint16_t> max_vote_author_promote_rate;
         };
 
         struct optional_private_box_query {
@@ -1686,7 +1689,8 @@ FC_REFLECT((golos::wallet::optional_chain_props),
     (max_delegated_vesting_interest_rate)(custom_ops_bandwidth_multiplier)(min_curation_percent)(max_curation_percent)
     (curation_reward_curve)(allow_distribute_auction_reward)(allow_return_auction_reward_to_fund)
     (worker_from_content_fund_percent)(worker_from_vesting_fund_percent)(worker_from_witness_fund_percent)
-    (worker_techspec_approve_term_sec)(worker_result_approve_term_sec))
+    (worker_techspec_approve_term_sec)(worker_result_approve_term_sec)
+    (min_vote_author_promote_rate)(max_vote_author_promote_rate))
 
 FC_REFLECT(
     (golos::wallet::message_body),

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -352,6 +352,8 @@ namespace golos { namespace wallet {
                         result["worker_from_witness_fund_percent"] = median_props.worker_from_witness_fund_percent;
                         result["worker_techspec_approve_term_sec"] = median_props.worker_techspec_approve_term_sec;
                         result["worker_result_approve_term_sec"] = median_props.worker_result_approve_term_sec;
+                        result["min_vote_author_promote_rate"] = median_props.min_vote_author_promote_rate;
+                        result["max_vote_author_promote_rate"] = median_props.max_vote_author_promote_rate;
                     }
 
                     return result;
@@ -2294,7 +2296,8 @@ fc::ecc::private_key wallet_api::derive_private_key(const std::string& prefix_st
             auto hf = my->_remote_database_api->get_hardfork_version();
             if (hf >= hardfork_version(0, STEEMIT_HARDFORK_0_21) || !!props.worker_from_content_fund_percent
                     || !!props.worker_from_vesting_fund_percent || !!props.worker_from_witness_fund_percent
-                    || !!props.worker_techspec_approve_term_sec || !!props.worker_result_approve_term_sec) {
+                    || !!props.worker_techspec_approve_term_sec || !!props.worker_result_approve_term_sec
+                    || !!props.min_vote_author_promote_rate || !!props.max_vote_author_promote_rate) {
                 chain_properties_21 p21;
                 p21 = p;
                 SET_PROP(p21, worker_from_content_fund_percent);
@@ -2302,6 +2305,8 @@ fc::ecc::private_key wallet_api::derive_private_key(const std::string& prefix_st
                 SET_PROP(p21, worker_from_witness_fund_percent);
                 SET_PROP(p21, worker_techspec_approve_term_sec);
                 SET_PROP(p21, worker_result_approve_term_sec);
+                SET_PROP(p21, min_vote_author_promote_rate);
+                SET_PROP(p21, max_vote_author_promote_rate);
                 op.props = p21;
             }
 #undef SET_PROP


### PR DESCRIPTION
Resolve #1062:
- Witnesses can limit author promote rate with min-max-median (force promoting with min limit and limit promoting with max limit).
- Bounds for this median are 0% and 100% (no bounds).