### PR TITLE
Vote author promote improve #1356 and tests #1355

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -2374,6 +2374,10 @@ namespace golos { namespace chain {
                     for (auto itr = c.vote_list.begin(); c.vote_list.end() != itr; ++itr) {
                         uint128_t weight(itr->weight);
                         uint64_t claim = ((max_rewards.value * weight) / total_weight).to_uint64();
+                        if (has_hardfork(STEEMIT_HARDFORK_0_22__1014)) {
+                            claim -= (uint128_t(claim) * (*itr->vote).author_promote_rate / STEEMIT_100_PERCENT).to_uint64();
+                        }
+
                         // to_curators case
                         if (c.comment.auction_window_reward_destination == protocol::to_curators &&
                             itr->vote->auction_time == c.comment.auction_window_size
@@ -2390,9 +2394,6 @@ namespace golos { namespace chain {
                         }
 
                         if (claim > 0) { // min_amt is non-zero satoshis
-                            if (has_hardfork(STEEMIT_HARDFORK_0_22__1014)) {
-                                claim -= (uint128_t(claim) * (*itr->vote).author_promote_rate / STEEMIT_100_PERCENT).to_uint64();
-                            }
                             unclaimed_rewards -= claim;
                             pay_curator(*itr->vote, claim, c.comment.author, to_string(c.comment.permlink));
                         } else {

--- a/tests/common/comment_reward.hpp
+++ b/tests/common/comment_reward.hpp
@@ -237,6 +237,11 @@ namespace golos { namespace chain {
                 BOOST_REQUIRE(vote_payout_map_.find(itr->vote->voter) == vote_payout_map_.end());
                 auto weight = u256(itr->weight);
                 uint64_t claim = static_cast<uint64_t>(weight * vote_rewards_fund_ / total_weight);
+                if (db_.has_hardfork(STEEMIT_HARDFORK_0_22__1014)) {
+                    auto promote_reward = claim * itr->vote->author_promote_rate / STEEMIT_100_PERCENT;
+                    claim -= promote_reward;
+                }
+
                 // to_curators case
                 if (comment_.auction_window_reward_destination == protocol::to_curators &&
                     (itr->vote->last_update >= auw_time || db_.get(itr->vote->voter).name == comment_.author)

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -7844,7 +7844,202 @@ BOOST_FIXTURE_TEST_SUITE(operation_tests, clean_database_fixture)
 
     BOOST_AUTO_TEST_SUITE_END() // comment_curation_rewards_percent
 
-BOOST_AUTO_TEST_SUITE_END()
+    BOOST_AUTO_TEST_SUITE(vote_options) // vote_options
+
+    BOOST_AUTO_TEST_CASE(vote_options_authorities) { try {
+        BOOST_TEST_MESSAGE("Testing: vote_options_authorities");
+
+        vote_options_operation op;
+        op.voter = "bob";
+        op.author = "alice";
+        op.permlink = "test";
+        CHECK_OP_AUTHS(op, account_name_set(), account_name_set(), account_name_set({"bob"}));
+    } FC_LOG_AND_RETHROW() }
+
+    BOOST_AUTO_TEST_CASE(vote_options_validate) { try {
+        BOOST_TEST_MESSAGE("Testing: vote_options_validate");
+
+        BOOST_TEST_MESSAGE("-- Normal case");
+
+        vote_options_operation op;
+        op.voter = "bob";
+        op.author = "alice";
+        op.permlink = "test";
+        CHECK_OP_VALID(op);
+
+        BOOST_TEST_MESSAGE("-- Incorrect account or permlink case");
+
+        CHECK_PARAM_INVALID(op, voter, "");
+        CHECK_PARAM_INVALID(op, author, "");
+        CHECK_PARAM_INVALID(op, permlink, std::string(STEEMIT_MAX_PERMLINK_LENGTH+1, ' '));
+
+    } FC_LOG_AND_RETHROW() }
+
+    BOOST_AUTO_TEST_CASE(author_promote_rate_validate) { try {
+        BOOST_TEST_MESSAGE("Testing: author_promote_rate_validate");
+
+        vote_options_operation op;
+        op.voter = "bob";
+        op.author = "alice";
+        op.permlink = "test";
+
+        BOOST_TEST_MESSAGE("-- Normal case with author_promote_rate");
+
+        vote_options_extensions_type op_exts;
+        op_exts.insert(vote_author_promote_rate(0));
+        CHECK_PARAM_VALID(op, extensions, op_exts);
+
+        op_exts.clear();
+        op_exts.insert(vote_author_promote_rate(STEEMIT_100_PERCENT));
+        CHECK_PARAM_VALID(op, extensions, op_exts);
+
+        BOOST_TEST_MESSAGE("-- author_promote_rate < 0");
+
+        op.extensions.clear();
+        op.extensions.insert(vote_author_promote_rate(-1));
+        GOLOS_CHECK_ERROR_PROPS(op.validate(),
+            CHECK_ERROR(invalid_parameter, "rate"));
+
+        BOOST_TEST_MESSAGE("-- author_promote_rate > 100%");
+
+        op.extensions.clear();
+        op.extensions.insert(vote_author_promote_rate(STEEMIT_100_PERCENT+1));
+        GOLOS_CHECK_ERROR_PROPS(op.validate(),
+            CHECK_ERROR(invalid_parameter, "rate"));
+
+    } FC_LOG_AND_RETHROW() }
+
+    BOOST_AUTO_TEST_CASE(vote_options_apply) { try {
+        BOOST_TEST_MESSAGE("Testing: vote_options_apply");
+
+        signed_transaction tx;
+        ACTORS((alice)(bob))
+        fund("alice", 10000);
+        vest("alice", 10000);
+        fund("bob", 10000);
+        vest("bob", 10000);
+        generate_block();
+
+        BOOST_TEST_MESSAGE("--- Testing without comment");
+
+        vote_options_operation op;
+        op.voter = "bob";
+        op.author = "alice";
+        op.permlink = "alice-test";
+
+        GOLOS_CHECK_ERROR_MISSING(comment, make_comment_id("alice", "alice-test"), bob_private_key, op);
+
+        BOOST_TEST_MESSAGE("--- Creating comment");
+
+        comment_create("alice", alice_private_key, "alice-test", "", "alice-test");
+        generate_block();
+
+        BOOST_TEST_MESSAGE("--- Testing without vote");
+
+        GOLOS_CHECK_ERROR_MISSING(comment_vote_object, fc::mutable_variant_object()("voter",op.voter)("author",op.author)("permlink",op.permlink),
+            bob_private_key, op);
+
+        BOOST_TEST_MESSAGE("--- Voting for comment");
+
+        vote_operation vote_op;
+        vote_op.voter = "bob";
+        vote_op.author = "alice";
+        vote_op.permlink = "alice-test";
+        vote_op.weight = 1000;
+        BOOST_CHECK_NO_THROW(push_tx_with_ops(tx, bob_private_key, vote_op));
+        generate_block();
+
+        BOOST_TEST_MESSAGE("--- Normal call without extensions");
+
+        BOOST_CHECK_NO_THROW(push_tx_with_ops(tx, bob_private_key, op));
+        generate_block();
+
+        validate_database();
+    } FC_LOG_AND_RETHROW() }
+
+    BOOST_AUTO_TEST_CASE(author_promote_rate_apply) { try {
+        BOOST_TEST_MESSAGE("Testing: author_promote_rate_apply");
+
+        signed_transaction tx;
+        ACTORS((alice)(bob))
+        fund("alice", 10000);
+        vest("alice", 10000);
+        fund("bob", 10000);
+        vest("bob", 10000);
+        generate_block();
+
+        auto& wso = db->get_witness_schedule_object();
+        BOOST_CHECK_EQUAL(wso.median_props.min_vote_author_promote_rate, GOLOS_MIN_VOTE_AUTHOR_PROMOTE_RATE);
+        BOOST_CHECK_EQUAL(wso.median_props.max_vote_author_promote_rate, GOLOS_MAX_VOTE_AUTHOR_PROMOTE_RATE);
+
+        set_price_feed(price(ASSET("1.000 GOLOS"), ASSET("1.000 GBG")));
+
+        BOOST_TEST_MESSAGE("--- Creating comment and voting for it");
+
+        comment_create("alice", alice_private_key, "alice-test", "", "alice-test");
+        generate_block();
+        vote_operation vote_op;
+        vote_op.voter = "bob";
+        vote_op.author = "alice";
+        vote_op.permlink = "alice-test";
+        vote_op.weight = 1000;
+        BOOST_CHECK_NO_THROW(push_tx_with_ops(tx, bob_private_key, vote_op));
+        generate_block();
+
+        {
+            auto vote = db->get<comment_vote_object, by_comment_voter>(std::make_tuple(db->get_comment("alice", string("alice-test")).id, db->get_account("bob").id));
+            BOOST_CHECK_EQUAL(vote.author_promote_rate, wso.median_props.min_vote_author_promote_rate);
+        }
+
+        BOOST_TEST_MESSAGE("--- Testing with normal value");
+
+        vote_options_operation op;
+        op.voter = "bob";
+        op.author = "alice";
+        op.permlink = "alice-test";
+        vote_author_promote_rate vapr(25 * STEEMIT_1_PERCENT);
+        op.extensions.insert(vapr);
+        BOOST_CHECK_NO_THROW(push_tx_with_ops(tx, bob_private_key, op));
+        generate_block();
+        {
+            auto vote = db->get<comment_vote_object, by_comment_voter>(std::make_tuple(db->get_comment("alice", string("alice-test")).id, db->get_account("bob").id));
+            BOOST_CHECK_EQUAL(vote.author_promote_rate, vapr.rate);
+        }
+
+        BOOST_TEST_MESSAGE("--- Checking that calling without extensions don't affect value");
+
+        op.extensions.clear();
+        BOOST_CHECK_NO_THROW(push_tx_with_ops(tx, bob_private_key, op));
+        generate_block();
+        {
+            auto vote = db->get<comment_vote_object, by_comment_voter>(std::make_tuple(db->get_comment("alice", string("alice-test")).id, db->get_account("bob").id));
+            BOOST_CHECK_EQUAL(vote.author_promote_rate, vapr.rate);
+        }
+
+        BOOST_TEST_MESSAGE("--- Starting rewards");
+
+        generate_blocks(db->get_comment("alice", string("alice-test")).cashout_time - STEEMIT_BLOCK_INTERVAL, false);
+
+        comment_fund total_comment_fund(*db);
+        comment_reward alice_comment_reward(*db, total_comment_fund, db->get_comment("alice", string("alice-test")));
+
+        generate_block();
+
+        BOOST_TEST_MESSAGE("--- Checking rewards");
+
+        auto& bob_account = db->get_account("bob");
+        auto cur_op = get_last_operations<curation_reward_operation>(1)[0];
+        BOOST_CHECK_EQUAL(cur_op.reward, alice_comment_reward.vote_payout(bob_account));
+        auto author_op = get_last_operations<author_reward_operation>(1)[0];
+        BOOST_CHECK_EQUAL(author_op.sbd_payout, alice_comment_reward.sbd_payout());
+        BOOST_CHECK_EQUAL(author_op.vesting_payout, alice_comment_reward.vesting_payout());
+
+        validate_database();
+    } FC_LOG_AND_RETHROW() }
+
+    BOOST_AUTO_TEST_SUITE_END() // vote_options
+
+BOOST_AUTO_TEST_SUITE_END() // operation_tests
 
 
 struct votes_extended_fixture : public golos::chain::clean_database_fixture {


### PR DESCRIPTION
Resolves #1356:
- Now it doesn't cuts from voter claim + voter auction reward, but cuts only from voter claim. I think it is more logically because voter allowed cutting only his voter claim, also it doesn't complicates calculation of voter auction reward.

Resolves #1355:
- Added tests on `vote_options` operation.
- Added tests on `author_promote_rate` extension of this operation. (Future extensions to `vote_options`-operation also will be separated test cases.)