### PR TITLE
Add some not-enough info to API

### DIFF
--- a/libraries/api/chain_api_properties.cpp
+++ b/libraries/api/chain_api_properties.cpp
@@ -40,6 +40,7 @@ namespace golos { namespace api {
             worker_from_vesting_fund_percent = src.worker_from_vesting_fund_percent;
             worker_from_witness_fund_percent = src.worker_from_witness_fund_percent;
             worker_techspec_approve_term_sec = src.worker_techspec_approve_term_sec;
+            worker_result_approve_term_sec = src.worker_result_approve_term_sec;
             min_vote_author_promote_rate = src.min_vote_author_promote_rate;
             max_vote_author_promote_rate = src.max_vote_author_promote_rate;
         }

--- a/libraries/api/discussion_helper.cpp
+++ b/libraries/api/discussion_helper.cpp
@@ -213,6 +213,7 @@ namespace golos { namespace api {
             vstate.weight = itr->weight;
             vstate.rshares = itr->vote->rshares;
             vstate.percent = itr->vote->vote_percent;
+            vstate.author_promote_percent = itr->vote->author_promote_rate;
             vstate.time = itr->vote->last_update;
             fill_reputation_(database(), vo.name, vstate.reputation);
             result.emplace_back(std::move(vstate));

--- a/libraries/api/include/golos/api/vote_state.hpp
+++ b/libraries/api/include/golos/api/vote_state.hpp
@@ -9,6 +9,7 @@ namespace golos { namespace api {
         uint64_t weight = 0;
         int64_t rshares = 0;
         int16_t percent = 0;
+        int16_t author_promote_percent = 0;
         fc::optional<share_type> reputation;
         time_point_sec time;
     };
@@ -16,4 +17,4 @@ namespace golos { namespace api {
 } } // golos::api
 
 
-FC_REFLECT((golos::api::vote_state), (voter)(weight)(rshares)(percent)(reputation)(time));
+FC_REFLECT((golos::api::vote_state), (voter)(weight)(rshares)(percent)(author_promote_percent)(reputation)(time));


### PR DESCRIPTION
Resolves #1380 :
- Found one field in chain API props related to workers, which is not initializing.
- Provided a minimal data for client calculation of author promotes (it is just 3 lined of code but now client can at least show promote rates in vote list, and use their sum to clarify pending payout calculation - by himself).